### PR TITLE
Add NetCat to support bastion host proxy.

### DIFF
--- a/ansible/bastion-host.yml
+++ b/ansible/bastion-host.yml
@@ -3,3 +3,7 @@
   become: true
   roles:
     - base-os
+
+  tasks:
+    - name: Install Netcat for SSH Proxy Command
+      apt: name=netcat state=present


### PR DESCRIPTION
#### What's this PR do?
* Add `netcat` package to bastion host playbook to allow SSH proxy.

#### Where should the reviewer start?
* bastion-host.yml file.

#### How should this be manually tested?
* Already tested for `qm1`

#### Any background context you want to provide?
* Moving towards not storing private keys on servers, as well as allowing users to directly SSH to server they need to.

#### What are the relevant tickets?
#46 

#### Screenshots (if appropriate)

#### Questions:

