### PR TITLE
Updated to create global env path by environment.

### DIFF
--- a/ansible/roles/base-os/tasks/main.yml
+++ b/ansible/roles/base-os/tasks/main.yml
@@ -90,7 +90,19 @@
   with_items: "{{qa_users}}"
   when: appuser is defined and appuser == "QA"
 
+## Prod Data Application User
+
 - name: User Setup | Add Prod App User
   user: name ={{ item }} shell=/bin/bash
   with_items: "{{prod_users}}"
+  when: appuser is defined and appuser == "PROD"
+
+## Create Env Directory Used by App User
+
+- name: Create QA Env Dir
+  file: path=/env state=directory owner=quantum group=quantum mode=750 recurse=yes
+  when: appuser is defined and appuser == "QA"
+
+- name: Create Prod Env Dir
+  file: path=/env state=directory owner=quasar group=quasar mode=750 recurse=yes
   when: appuser is defined and appuser == "PROD"


### PR DESCRIPTION
#### What's this PR do?
Add `/env` as a global app environment app directory.

#### Where should the reviewer start?
Below!

#### How should this be manually tested?
Already done on Quantum Compute

#### Any background context you want to provide?
Most of the Data 1.0 etl-scripts repo use `sys.path.append` to add an absolute path that I'm flattening down to a global one to cleanup the scripts, and make QA and migrating Prod to Google Compute a lot easier.

#### What are the relevant tickets?
#67 
#### Screenshots (if appropriate)
#### Questions:

