### PR TITLE
Adding global etl-scripts run path.

### DIFF
--- a/ansible/roles/data-1-compute/tasks/main.yml
+++ b/ansible/roles/data-1-compute/tasks/main.yml
@@ -26,3 +26,17 @@
     - requests
     - SQLAlchemy
     - lxml
+
+## The following has a dependency on the `base-os` role "appuser"
+#  being defined.
+
+# Create QA User owned script run-path
+
+- name: Create etl-scripts Run Directory
+  file: path=/etl-scripts state=directory owner=quantum group=quantum mode=750
+  when: appuser is defined and appuser == "QA"
+
+ 
+- name: Create etl-scripts Run Directory
+  file: path=/etl-scripts state=directory owner=quasar group=quasar mode=750
+  when: appuser is defined and appuser == "PROD"


### PR DESCRIPTION
#### What's this PR do?
Takes `etl-scripts` path to be absolute from server root, instead of user home directory.

#### Where should the reviewer start?
Below.

#### How should this be manually tested?
Already done.

#### Any background context you want to provide?
`etl-scripts` have some relative and home directory path assumptions that are no longer valid.

#### What are the relevant tickets?
#67.

#### Screenshots (if appropriate)

#### Questions:
Am I just going to approve my own PR?