### PR TITLE
Removing read_only option for Looker PDT.

### DIFF
--- a/ansible/roles/percona-57/templates/data-mysql.cnf.j2
+++ b/ansible/roles/percona-57/templates/data-mysql.cnf.j2
@@ -16,7 +16,7 @@ log_bin_index	= /var/lib/mysql/{{ ansible_hostname }}-bin.index
 relay-log	= /var/lib/mysql/{{ ansible_hostname }}-relay-bin
 expire_logs_days = 3
 log-slave-updates = 1
-read-only	= 1
+read-only	= 0
 sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
 
 # Tuning Section


### PR DESCRIPTION
#### What's this PR do?
Set's MySQL `read_only` variable to 0/OFF to allow Looker to use temporary table space and PDT's.

#### Where should the reviewer start?
https://github.com/DoSomething/quasar/blob/read-only-off/ansible/roles/percona-57/templates/data-mysql.cnf.j2#L19

#### How should this be manually tested?
Variable set live on Prod worked, and tested.


