### PR TITLE
Modified profile API test script to not use Python 2 "long" type.

### DIFF
--- a/etl-scripts/jc_profile_api_test.py
+++ b/etl-scripts/jc_profile_api_test.py
@@ -91,7 +91,7 @@ def insert_to_db_mobile(obj, db, cur):
       pass
     if obj[k] is None or obj[k] == '':
       values.append('NULL')
-    elif type(obj[k]) == int or type(obj[k]) == long:
+    elif type(obj[k]) == int:
       values.append(str(obj[k]))
     elif type(obj[k]) == d:
       values.append(str(obj[k]).join(['"', '"']))
@@ -117,7 +117,7 @@ def insert_to_db_web(obj, db, cur):
       pass
     if obj[k] is None or obj[k] == '':
       values.append('NULL')
-    elif type(obj[k]) == int or type(obj[k]) == long:
+    elif type(obj[k]) == int:
       values.append(str(obj[k]))
     elif type(obj[k]) == d:
       values.append(str(obj[k]).join(['"', '"']))


### PR DESCRIPTION
#### What's this PR do?

* Updated Profile Update ETL script to not use "long" type in two if loops, since the "int" type in Python3 covers all integer types.

#### Where should the reviewer start?

The one file here.

#### How should this be manually tested?

Limited testing done in Quasar. (*For the love of all that is holy I need a local dev environment*).


