### PR TITLE
Northstar ETL Update - Fast Mode and Paginate to Complete

### DIFF
--- a/etl-scripts/DSNorthstarScraper.py
+++ b/etl-scripts/DSNorthstarScraper.py
@@ -41,10 +41,23 @@ class NorthstarScraper(Scraper):
             users (int): Users per page returned, default 100, max 100.
             page_number (int): Page number to return, default 1.
         """
-        user_response = self.get('/v1/users', {'limit': users, 'page': page_number})
+        user_response = self.get('/v1/users', {'limit': users, 'page': page_number, 'pagination': 'cursor'})
         return(user_response['data'])
 
     def userCount(self, users=100, page_number=1):
         """Get total user count and pages."""
         get_count = self.get('/v1/users', {'limit': users, 'page': page_number})
         return(get_count['meta']['pagination']['total'], get_count['meta']['pagination']['total_pages'])
+
+    def nextPageStatus(self, users=100, page_number=1):
+        """Get users in max batch size by default from Northstar API.
+
+        Args:
+            users (int): Users per page returned, default 100, max 100.
+            page_number (int): Page number to return, default 1.
+        """
+        user_response = self.get('/v1/users', {'limit': users, 'page': page_number, 'pagination': 'cursor'})
+        if user_response['meta']['cursor']['next'] is None:
+            return False
+        else:
+            return user_response['meta']['cursor']['next']

--- a/etl-scripts/DSNorthstarScraper.py
+++ b/etl-scripts/DSNorthstarScraper.py
@@ -44,13 +44,23 @@ class NorthstarScraper(Scraper):
         user_response = self.get('/v1/users', {'limit': users, 'page': page_number, 'pagination': 'cursor'})
         return(user_response['data'])
 
+    def getUsersSlow(self, users=100, page_number=1):
+        """Get users in max batch size by default from Northstar API.
+
+        Args:
+            users (int): Users per page returned, default 100, max 100.
+            page_number (int): Page number to return, default 1.
+        """
+        user_response = self.get('/v1/users', {'limit': users, 'page': page_number})
+        return(user_response['data'])
+
     def userCount(self, users=100, page_number=1):
         """Get total user count and pages."""
         get_count = self.get('/v1/users', {'limit': users, 'page': page_number})
         return(get_count['meta']['pagination']['total'], get_count['meta']['pagination']['total_pages'])
 
     def nextPageStatus(self, users=100, page_number=1):
-        """Get users in max batch size by default from Northstar API.
+        """Check next page pagination to see if null or not.
 
         Args:
             users (int): Users per page returned, default 100, max 100.
@@ -60,4 +70,4 @@ class NorthstarScraper(Scraper):
         if user_response['meta']['cursor']['next'] is None:
             return False
         else:
-            return user_response['meta']['cursor']['next']
+            return True

--- a/etl-scripts/northstar_to_user_table.py
+++ b/etl-scripts/northstar_to_user_table.py
@@ -21,7 +21,12 @@ start_time = time.time()
 """Keep track of start time of script."""
 
 ns_fetcher = NorthstarScraper()
+
+# Set pagination variable to be true by default. This
+# will track whether there are any more pages in a
+# result set. If there aren't, will return false.
 nextPage = True
+
 
 db = MySQLdb.connect(host=config.host,  # hostname
                      user=config.user,  # username
@@ -43,6 +48,7 @@ if len(sys.argv) < 2:
 else:
     i = int(sys.argv[1])
 """Check if page start point provided, otherwise use last processed point."""
+
 
 def to_string(base_value):
     """Converts to string and replaces values with NULL when blank or None."""
@@ -95,7 +101,6 @@ while nextPage is True:
         cur.execute(query)
         db.commit()
     nextPage = ns_fetcher.nextPageStatus(100, i)
-    print(nextPage)
     if nextPage is True:
         i += 1
         cur.execute("REPLACE INTO quasar_etl_status.northstar_ingestion \

--- a/etl-scripts/northstar_to_user_table.py
+++ b/etl-scripts/northstar_to_user_table.py
@@ -57,6 +57,7 @@ def to_string(base_value):
     transform_null = re.sub(r'^$|\bNone\b', 'NULL', strip_special_chars)
     return str(transform_null)
 
+
 while nextPage is True:
     current_page = ns_fetcher.getUsers(100, i)
     for user in current_page:

--- a/etl-scripts/thor_northstar_to_user_table.py
+++ b/etl-scripts/thor_northstar_to_user_table.py
@@ -21,6 +21,10 @@ start_time = time.time()
 """Keep track of start time of script."""
 
 ns_fetcher = NorthstarScraper('https://northstar-thor.dosomething.org')
+
+# Set pagination variable to be true by default. This
+# will track whether there are any more pages in a
+# result set. If there aren't, will return false.
 nextPage = True
 
 db = MySQLdb.connect(host=config.host,  # hostname
@@ -53,8 +57,7 @@ def to_string(base_value):
     return str(transform_null)
 
 
-# while i <= ns_pages:
-while ns_fetcher.nextPageStatus(100, i) is not None:
+while nextPage is True:
     current_page = ns_fetcher.getUsers(100, i)
     for user in current_page:
         query = "REPLACE INTO quasar.thor_users (northstar_id,\

--- a/etl-scripts/thor_northstar_to_user_table.py
+++ b/etl-scripts/thor_northstar_to_user_table.py
@@ -1,0 +1,108 @@
+import MySQLdb
+import config
+import time
+import re
+import sys
+from DSNorthstarScraper import NorthstarScraper
+
+"""DS Northstar to Quasar User ETL Test script.
+
+This ETL scripts scrapes the DoSomething Thor Northstar User API and ETL's the
+output to our MySQL Quasar data warehouse.
+
+The script takes an optional argument for what Northstar page result to start
+on. This is mostly used to backfill from a certain page, or from the dawn
+of time. Otherwise, pagination is stored in an small status tracking table
+that gets updated on ingestion loop.
+
+"""
+
+start_time = time.time()
+"""Keep track of start time of script."""
+
+ns_fetcher = NorthstarScraper('https://northstar-thor.dosomething.org')
+
+ns_member_counter = ns_fetcher.userCount()
+# ns_pages = ns_member_counter[1]
+# Get current max page number.
+
+db = MySQLdb.connect(host=config.host,  # hostname
+                     user=config.user,  # username
+                     passwd=config.pw)  # password
+
+db.set_character_set('utf8')
+cur = db.cursor()
+cur.execute('SET NAMES utf8;')
+cur.execute('SET CHARACTER SET utf8;')
+cur.execute('SET character_set_connection=utf8;')
+"""Set UTF-8 encoding on MySQL connection."""
+
+if len(sys.argv) < 2:
+    cur.execute("SELECT * from quasar_etl_status.thor_northstar_ingestion \
+                 WHERE counter_name = 'last_page_scraped';")
+    db.commit()
+    last_page = cur.fetchall()
+    i = last_page[0][1]
+else:
+    i = int(sys.argv[1])
+"""Check if page start point provided, otherwise use last processed point."""
+
+
+def to_string(base_value):
+    """Converts to string and replaces values with NULL when blank or None."""
+    base_string = str(base_value)
+    strip_special_chars = re.sub(r'[()<>/"\'\\]', '', base_string)
+    transform_null = re.sub(r'^$|\bNone\b', 'NULL', strip_special_chars)
+    return str(transform_null)
+
+
+# while i <= ns_pages:
+while ns_fetcher.nextPageStatus(100, i) is not None:
+    current_page = ns_fetcher.getUsers(100, i)
+    for user in current_page:
+        query = "REPLACE INTO quasar.thor_users (northstar_id,\
+                                            northstar_created_at_timestamp,\
+                                            drupal_uid,\
+                                            northstar_id_source_name,\
+                                            email, mobile, birthdate,\
+                                            first_name, last_name,\
+                                            addr_street1, addr_street2,\
+                                            addr_city, addr_state,\
+                                            addr_zip, country, language,\
+                                            agg_id, cgg_id)\
+                                            VALUES(\"{0}\",\"{1}\",{2},\"{3}\",\
+                                            \"{4}\",\"{5}\",\"{6}\",\"{7}\",\
+                                            \"{8}\",\"{9}\",\"{10}\",\"{11}\",\
+                                            \"{12}\",\"{13}\",\"{14}\",\"{15}\"\
+                                            ,NULL,NULL)".format(
+                                            to_string(user['id']),
+                                            to_string(user['created_at']),
+                                            to_string(user['drupal_id']),
+                                            to_string(user['source']),
+                                            to_string(user['email']),
+                                            to_string(user['mobile']),
+                                            to_string(user['birthdate']),
+                                            to_string(user['first_name']),
+                                            to_string(user['last_name']),
+                                            to_string(user['addr_street1']),
+                                            to_string(user['addr_street2']),
+                                            to_string(user['addr_city']),
+                                            to_string(user['addr_state']),
+                                            to_string(user['addr_zip']),
+                                            to_string(user['country']),
+                                            to_string(user['language']))
+        print(query)
+        cur.execute(query)
+        db.commit()
+    if ns_fetcher.nextPageStatus(100, i) is None:
+        break
+    else:
+        i += 1
+        cur.execute("REPLACE INTO quasar_etl_status.thor_northstar_ingestion \
+                (counter_name, counter_value) VALUES(\"last_page_scraped\",\
+                \"{0}\")".format(i))
+        db.commit()
+
+end_time = time.time()  # Record when script stopped running.
+duration = end_time - start_time  # Total duration in seconds.
+print('duration: ', duration)

--- a/etl-scripts/thor_northstar_to_user_table.py
+++ b/etl-scripts/thor_northstar_to_user_table.py
@@ -21,10 +21,7 @@ start_time = time.time()
 """Keep track of start time of script."""
 
 ns_fetcher = NorthstarScraper('https://northstar-thor.dosomething.org')
-
-ns_member_counter = ns_fetcher.userCount()
-# ns_pages = ns_member_counter[1]
-# Get current max page number.
+nextPage = True
 
 db = MySQLdb.connect(host=config.host,  # hostname
                      user=config.user,  # username
@@ -69,12 +66,16 @@ while ns_fetcher.nextPageStatus(100, i) is not None:
                                             addr_street1, addr_street2,\
                                             addr_city, addr_state,\
                                             addr_zip, country, language,\
-                                            agg_id, cgg_id)\
+                                            agg_id, cgg_id,\
+                                            moco_commons_profile_id,\
+                                            moco_current_status,\
+                                            moco_source_detail)\
                                             VALUES(\"{0}\",\"{1}\",{2},\"{3}\",\
                                             \"{4}\",\"{5}\",\"{6}\",\"{7}\",\
                                             \"{8}\",\"{9}\",\"{10}\",\"{11}\",\
                                             \"{12}\",\"{13}\",\"{14}\",\"{15}\"\
-                                            ,NULL,NULL)".format(
+                                            ,NULL,NULL,\"{16}\",\"{17}\",\
+                                            \"{18}\")".format(
                                             to_string(user['id']),
                                             to_string(user['created_at']),
                                             to_string(user['drupal_id']),
@@ -90,18 +91,62 @@ while ns_fetcher.nextPageStatus(100, i) is not None:
                                             to_string(user['addr_state']),
                                             to_string(user['addr_zip']),
                                             to_string(user['country']),
-                                            to_string(user['language']))
-        print(query)
+                                            to_string(user['language']),
+                                            to_string(user['mobilecommons_id']),
+                                            to_string(user['mobilecommons_status']),
+                                            to_string(user['source_detail']))
         cur.execute(query)
         db.commit()
-    if ns_fetcher.nextPageStatus(100, i) is None:
-        break
-    else:
+    nextPage = ns_fetcher.nextPageStatus(100, i)
+    if nextPage is True:
         i += 1
         cur.execute("REPLACE INTO quasar_etl_status.thor_northstar_ingestion \
                 (counter_name, counter_value) VALUES(\"last_page_scraped\",\
                 \"{0}\")".format(i))
         db.commit()
+    else:
+        current_page = ns_fetcher.getUsers(100, i)
+        for user in current_page:
+            query = "REPLACE INTO quasar.thor_users (northstar_id,\
+                                                northstar_created_at_timestamp,\
+                                                drupal_uid,\
+                                                northstar_id_source_name,\
+                                                email, mobile, birthdate,\
+                                                first_name, last_name,\
+                                                addr_street1, addr_street2,\
+                                                addr_city, addr_state,\
+                                                addr_zip, country, language,\
+                                                agg_id, cgg_id,\
+                                                moco_commons_profile_id,\
+                                                moco_current_status,\
+                                                moco_source_detail)\
+                                                VALUES(\"{0}\",\"{1}\",{2},\"{3}\",\
+                                                \"{4}\",\"{5}\",\"{6}\",\"{7}\",\
+                                                \"{8}\",\"{9}\",\"{10}\",\"{11}\",\
+                                                \"{12}\",\"{13}\",\"{14}\",\"{15}\"\
+                                                ,NULL,NULL,\"{16}\",\"{17}\",\
+                                                \"{18}\")".format(
+                                                to_string(user['id']),
+                                                to_string(user['created_at']),
+                                                to_string(user['drupal_id']),
+                                                to_string(user['source']),
+                                                to_string(user['email']),
+                                                to_string(user['mobile']),
+                                                to_string(user['birthdate']),
+                                                to_string(user['first_name']),
+                                                to_string(user['last_name']),
+                                                to_string(user['addr_street1']),
+                                                to_string(user['addr_street2']),
+                                                to_string(user['addr_city']),
+                                                to_string(user['addr_state']),
+                                                to_string(user['addr_zip']),
+                                                to_string(user['country']),
+                                                to_string(user['language']),
+                                                to_string(user['mobilecommons_id']),
+                                                to_string(user['mobilecommons_status']),
+                                                to_string(user['source_detail']))
+            cur.execute(query)
+            db.commit()
 
 end_time = time.time()  # Record when script stopped running.
 duration = end_time - start_time  # Total duration in seconds.


### PR DESCRIPTION
#### What's this PR do?
* Changes ETL extract to use "next page" in processing requests from Northstar instead of static limit when ETL process starts. Essentially jobs will run through to end of time period/request than 
missing potential new pages that come in.
* Adds testing for Thor Northstar endpoint as first step towards a QA environment. 
* Updated DS Northstar Scraper to default to `fast` mode.
* Added nextPageStatus method to DS Northstar Scraper to figure out if there are any pages left or not. 
* Added 3 new fields required by Quasar schema. Still missing `updated_at`. Will add via another PR, since it has to scrape the entire Northstar data set again.

#### Where should the reviewer start?

https://github.com/DoSomething/quasar/blob/thor-northstar-ETL-test/etl-scripts/DSNorthstarScraper.py

#### How should this be manually tested?

Already tested against Thor Northstar API endpoint as working. 

#### What are the relevant tickets?
https://github.com/DoSomething/quasar/issues/294
#310 


