### PR TITLE
For some reason querying for Northstar ID requires some string

### DIFF
--- a/etl-scripts/mailchimp_subscriber_to_user_table.py
+++ b/etl-scripts/mailchimp_subscriber_to_user_table.py
@@ -1,4 +1,5 @@
 import requests
+import re
 from requests.auth import HTTPBasicAuth
 import time
 from datetime import datetime
@@ -17,6 +18,12 @@ def isInt(s):
         return True
     except ValueError:
         return False
+
+def _bare_str(base_value):
+    """Convert value to string and strips special characters."""
+    base_string = str(base_value)
+    strip_special_chars = re.sub(r'[()<>/"\,\'\\]', '', base_string)
+    return str(strip_special_chars)
 
 mc_increment = 1000
 
@@ -109,7 +116,7 @@ while (len(member_array['members'])) > 1:
                 pass
             else:
                 for x in range(0, northstar_email_matches):
-                    northstar_id = cur.fetchone()
+                    northstar_id = _bare_str(cur.fetchone())
                     first_subscribed = submember['timestamp_opt'].replace('T', ' ').split('+')[0]
                     status = submember['status']
                     list_id = submember['list_id']


### PR DESCRIPTION

#### What's this PR do?
For some reason querying for Northstar ID requires some string casting and manipulation to remove extraneous characters it didn't before.

Added `_bare_str` function that will go into future helper library
as a quick fix to get MailChimp imports back on track after failing
for the past 48 hours or so.

#### Where should the reviewer start?
File below.
#### How should this be manually tested?
Manually tested in prod.
#### Questions:
What did this start happening.