### PR TITLE
Using Publish instead of Basic_Nack Requeing

### DIFF
--- a/etl-scripts/QuasarCustomerIOQueue.py
+++ b/etl-scripts/QuasarCustomerIOQueue.py
@@ -110,8 +110,12 @@ class QuasarQueue:
                              "".format(message_data['meta']['request_id']))
                 return True
             else:
-                self.channel.basic_nack(method_frame.delivery_tag,
-                                        requeue=True)
+                self.channel.basic_publish(self.amqp_exchange, self.amqp_queue,
+                                           self._body_encode(message_data),
+                                           pika.BasicProperties(
+                                               content_type='application/json',
+                                               delivery_mode=2))
+                self.channel.basic_ack(method_frame.delivery_tag)
                 logging.info("[Message {0}] Message failed, requeueing "
                              "single message and exiting till next run..."
                              "".format(message_data['meta']['request_id']))


### PR DESCRIPTION
#### What's this PR do?
Changes `basic_nack` to actually republish message with persistence, since it appears basic_nack doesn't send message back to top of queue.

#### Where should the reviewer start?
One file below.

#### How should this be manually tested?
Tested in prod.

#### What are the relevant tickets?
#351 

#### Questions:
Why didn't `basic_nack` or `basic_reject` work as expected?