### PR TITLE
Blink queue sleep improvement

### DIFF
--- a/etl-scripts/QuasarCustomerIOQueue.py
+++ b/etl-scripts/QuasarCustomerIOQueue.py
@@ -120,6 +120,7 @@ class QuasarQueue:
                 logging.info("[Message {0}] Message failed, requeueing "
                              "message and trying the next one."
                              "".format(message_data['meta']['request_id']))
+                logging.info("Retry counter at {0}.".format(retry_counter))
                 retry_counter += 1
                 time.sleep(1)
             else:

--- a/etl-scripts/QuasarCustomerIOQueue.py
+++ b/etl-scripts/QuasarCustomerIOQueue.py
@@ -121,7 +121,8 @@ class QuasarQueue:
                 logging.info("[Message {0}] Message failed, requeueing "
                              "message and trying the next one."
                              "".format(message_data['meta']['request_id']))
-                logging.info("Retry counter at {0}.".format(self.retry_counter))
+                logging.info("Retry counter at {0}."
+                             "".format(self.retry_counter))
                 time.sleep(1)
             else:
                 logging.info("Max retry counter reached, exiting for now.")


### PR DESCRIPTION
#### What's this PR do?
Updates Quasar Blink Queue consumer to handle unparseable messages that don't yet contain a Northstar ID with a sleep function and exit on 1000 retries.

#### Where should the reviewer start?
One altered file. 

#### How should this be manually tested?
Unproudly tested and verified running in prod. 

#### Any background context you want to provide?
Our current approach creates a queue backlog condition of interleaved good and bad messages, because it exists on all unparseable messages that can get updated every 5 minutes in the users table. This PR implements a much better approach by not running forever, but also giving the queue enough attempts at trying messages while parsing good messages between bad ones.
