### PR TITLE
Use column name `signup_id`, instead of `signup_event_id`

### DIFF
--- a/etl-scripts/QuasarCampaignActivityParsing.py
+++ b/etl-scripts/QuasarCampaignActivityParsing.py
@@ -91,7 +91,7 @@ class RogueEtl:
                 self.db.query_str("INSERT INTO " +
                                   self.campaign_activity_table +
                                   " SET northstar_id = %s,\
-                                  signup_event_id = %s,\
+                                  signup_id = %s,\
                                   campaign_id = %s,\
                                   campaign_run_id = %s,\
                                   quantity = %s,\
@@ -120,7 +120,7 @@ class RogueEtl:
                     self.db.query_str("INSERT INTO " +
                                       self.campaign_activity_table +
                                       " SET northstar_id = %s,\
-                                      signup_event_id = %s,\
+                                      signup_id = %s,\
                                       campaign_id = %s,\
                                       campaign_run_id = %s,\
                                       quantity = %s,\


### PR DESCRIPTION
#### What's this PR do?
Data Warehouse `campaign_activity` column updated to use `signup_id` instead of `signup_event_id`.
#### Where should the reviewer start?
Two lines of code changed.
#### How should this be manually tested?
Unproudly tested in Prod.
#### Any background context you want to provide?

#### What are the relevant tickets?
#363

