### PR TITLE
Update NULL value on submission_created_at date to have empty value

### DIFF
--- a/etl-scripts/QuasarCampaignActivityParsing.py
+++ b/etl-scripts/QuasarCampaignActivityParsing.py
@@ -91,7 +91,7 @@ class RogueEtl:
                 self.db.query_str("INSERT INTO " +
                                   self.campaign_activity_table +
                                   " SET northstar_id = %s,\
-                                  signup_event_id = %s,\
+                                  signup_id = %s,\
                                   campaign_id = %s,\
                                   campaign_run_id = %s,\
                                   quantity = %s,\
@@ -105,7 +105,7 @@ class RogueEtl:
                                   status = NULL,\
                                   remote_addr = NULL,\
                                   post_source = NULL,\
-                                  submission_created_at = NULL",
+                                  submission_created_at = ''",
                                   (dsh.bare_str(i['northstar_id']),
                                    dsh.bare_str(i['signup_id']),
                                    dsh.bare_str(i['campaign_id']),
@@ -120,7 +120,7 @@ class RogueEtl:
                     self.db.query_str("INSERT INTO " +
                                       self.campaign_activity_table +
                                       " SET northstar_id = %s,\
-                                      signup_event_id = %s,\
+                                      signup_id = %s,\
                                       campaign_id = %s,\
                                       campaign_run_id = %s,\
                                       quantity = %s,\


### PR DESCRIPTION
#### What's this PR do?
Updates Quasar Campaign record processing code to put empty value instead of NULL value in `submission_created_at` date, so the field can be used as part of a primary key.

#### Where should the reviewer start?
Few line changes.
#### How should this be manually tested?
Prod is my Staging, my QA, my All.
#### Any background context you want to provide?
We're adding a primary key to `campaign_activity` table to get more accurate record counts.
#### What are the relevant tickets?
#365 

