### PR TITLE
Make Record Updates from Northstar to Users Table non-destructive

### DIFF
--- a/etl-scripts/northstar_to_user_table.py
+++ b/etl-scripts/northstar_to_user_table.py
@@ -105,7 +105,7 @@ def to_string(base_value):
 while nextPage is True:
     current_page = ns_fetcher.getUsers(100, i)
     for user in current_page:
-        cur.execute("REPLACE INTO quasar.users (northstar_id,\
+        cur.execute("INSERT INTO quasar.users (northstar_id,\
                     northstar_created_at_timestamp,\
                     last_logged_in, last_accessed, drupal_uid,\
                     northstar_id_source_name,\
@@ -122,8 +122,42 @@ while nextPage is True:
                     %s,%s,%s,%s,\
                     %s,%s,%s,%s,\
                     %s,%s,%s,%s,\
-                    NULL,NULL,%s,%s,%s)",
+                    NULL,NULL,%s,%s,%s)\
+                    ON DUPLICATE KEY UPDATE \
+                    northstar_created_at_timestamp = %s,\
+                    last_logged_in = %s,\
+                    last_accessed = %s, drupal_uid = %s,\
+                    northstar_id_source_name = %s,\
+                    email = %s, mobile = %s, birthdate = %s,\
+                    first_name = %s, last_name = %s,\
+                    addr_street1 = %s, addr_street2 = %s,\
+                    addr_city = %s, addr_state = %s,\
+                    addr_zip = %s, country = %s, language = %s,\
+                    agg_id = NULL, cgg_id = NULL,\
+                    moco_commons_profile_id = %s,\
+                    moco_current_status = %s,\
+                    moco_source_detail = %s",
                     (to_string(user['id']),
+                     to_string(user['created_at']),
+                     to_string(user['last_authenticated_at']),
+                     to_string(user['last_accessed_at']),
+                     to_string(user['drupal_id']),
+                     to_string(user['source']),
+                     to_string(user['email']),
+                     to_string(user['mobile']),
+                     to_string(user['birthdate']),
+                     to_string(user['first_name']),
+                     to_string(user['last_name']),
+                     to_string(user['addr_street1']),
+                     to_string(user['addr_street2']),
+                     to_string(user['addr_city']),
+                     to_string(user['addr_state']),
+                     to_string(user['addr_zip']),
+                     to_string(user['country']),
+                     to_string(user['language']),
+                     to_string(user['mobilecommons_id']),
+                     to_string(user['mobilecommons_status']),
+                     to_string(user['source_detail']),
                      to_string(user['created_at']),
                      to_string(user['last_authenticated_at']),
                      to_string(user['last_accessed_at']),
@@ -155,7 +189,7 @@ while nextPage is True:
     else:
         current_page = ns_fetcher.getUsers(100, i)
         for user in current_page:
-            cur.execute("REPLACE INTO quasar.users (northstar_id,\
+            cur.execute("INSERT INTO quasar.users (northstar_id,\
                         northstar_created_at_timestamp,\
                         last_logged_in, last_accessed, drupal_uid,\
                         northstar_id_source_name,\
@@ -172,8 +206,42 @@ while nextPage is True:
                         %s,%s,%s,%s,\
                         %s,%s,%s,%s,\
                         %s,%s,%s,%s,\
-                        NULL,NULL,%s,%s,%s)",
+                        NULL,NULL,%s,%s,%s)\
+                        ON DUPLICATE KEY UPDATE \
+                        northstar_created_at_timestamp = %s,\
+                        last_logged_in = %s,\
+                        last_accessed = %s, drupal_uid = %s,\
+                        northstar_id_source_name = %s,\
+                        email = %s, mobile = %s, birthdate = %s,\
+                        first_name = %s, last_name = %s,\
+                        addr_street1 = %s, addr_street2 = %s,\
+                        addr_city = %s, addr_state = %s,\
+                        addr_zip = %s, country = %s, language = %s,\
+                        agg_id = NULL, cgg_id = NULL,\
+                        moco_commons_profile_id = %s,\
+                        moco_current_status = %s,\
+                        moco_source_detail = %s",
                         (to_string(user['id']),
+                         to_string(user['created_at']),
+                         to_string(user['last_authenticated_at']),
+                         to_string(user['last_accessed_at']),
+                         to_string(user['drupal_id']),
+                         to_string(user['source']),
+                         to_string(user['email']),
+                         to_string(user['mobile']),
+                         to_string(user['birthdate']),
+                         to_string(user['first_name']),
+                         to_string(user['last_name']),
+                         to_string(user['addr_street1']),
+                         to_string(user['addr_street2']),
+                         to_string(user['addr_city']),
+                         to_string(user['addr_state']),
+                         to_string(user['addr_zip']),
+                         to_string(user['country']),
+                         to_string(user['language']),
+                         to_string(user['mobilecommons_id']),
+                         to_string(user['mobilecommons_status']),
+                         to_string(user['source_detail']),
                          to_string(user['created_at']),
                          to_string(user['last_authenticated_at']),
                          to_string(user['last_accessed_at']),


### PR DESCRIPTION
#### What's this PR do?
Updated the Northstar->Users ETL script to use INSERT...ON DUPLICATE KEY UPDATE syntax to not overwrite pre-existing fields of data.
#### Where should the reviewer start?
One file below.
#### How should this be manually tested?
Already tested on test table in Prod environment.
#### Any background context you want to provide?
We previously used `REPLACE` which on a backfill update, nuked about 1M records fields we backfill from other ETL jobs to the same table.
#### What are the relevant tickets?
#374.

