### PR TITLE
Added Vagrant provision config to set sql-mode.

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -20,6 +20,8 @@ echo "Updated bind address to accept connections from all hosts"
 
 mysql -uroot -ppassword -e "GRANT ALL ON *.* to 'root'@'%' identified by 'password';"
 mysql -uroot -ppassword -e "FLUSH PRIVILEGES;"
+echo "[mysqld]" > /etc/mysql/conf.d/quasar.cnf
+echo "sql-mode=\"NO_ENGINE_SUBSTITUTION\"" >> /etc/mysql/conf.d/quasar.cnf
 sudo /etc/init.d/mysql restart
 
 MIGRATIONS=/vagrant/data/sql/migrations/*


### PR DESCRIPTION
#### What's this PR do?
Updates Vagrant provisioning file to create Quasar MySQL config that sets `sql-mode=NO_ENGINE_SUBSTITUTION` to match RDS defaults.

#### Where should the reviewer start?
Single file line below.
#### How should this be manually tested?
Run `vagrant provision` to update Vagrant box, and then check `SHOW GLOBAL VARIABLES` for `sql-mode`.

