### PR TITLE
Remove extraneous line that resets DB options to empty.

### DIFF
--- a/quasar/northstar_to_user_table_backfill.py
+++ b/quasar/northstar_to_user_table_backfill.py
@@ -166,7 +166,6 @@ def main():
 
     ca_settings = {'ca': '/home/quasar/rds-combined-ca-bundle.pem'}
     db_opts = {'use_unicode': True, 'charset': 'utf8', 'ssl': ca_settings}
-    db_opts = {}
     db, cur = database.connect(db_opts)
 
     if len(sys.argv) == 2:


### PR DESCRIPTION
#### What's this PR do?
Brilliantly, removed extraneous line that resets DB options to empty string, negating the re-added UTF8 params.

#### Where should the reviewer start?
One file below.

#### What are the relevant tickets?
#394 
