### PR TITLE
Override SSL in MySQL connection for local dev

### DIFF
--- a/quasar/config/__init__.py
+++ b/quasar/config/__init__.py
@@ -8,3 +8,5 @@ env = os.environ['ENV']
 if env == "PROD" or env == "STAGING":
     sys.path.append(os.environ.get("HOME"))
     import config as config
+
+config.env = env

--- a/quasar/config/dev.py
+++ b/quasar/config/dev.py
@@ -21,6 +21,7 @@ MYSQL_HOST = '127.0.0.1'
 MYSQL_PORT = 6603
 MYSQL_USER = 'root'
 MYSQL_PASSWORD = 'password'
+MYSQL_SSL = {}
 MYSQL_DATABASE = 'quasar'
 MYSQL_TABLE = 'users'
 BLINK_BACKUP_TABLE = 'blink_queue_backlog'

--- a/quasar/database.py
+++ b/quasar/database.py
@@ -38,6 +38,9 @@ class Database:
 
         opts.update(options)
 
+        if config.env == 'DEV':
+            opts['ssl'] = {}
+
         self.connection = _connect(opts)
         if self.connection is None:
             print("Error, couldn't connect to database with options:", opts)

--- a/quasar/database.py
+++ b/quasar/database.py
@@ -32,14 +32,12 @@ class Database:
             'port': config.MYSQL_PORT,
             'passwd': config.MYSQL_PASSWORD,
             'db': config.MYSQL_DATABASE,
+            'ssl': config.MYSQL_SSL,
             'use_unicode': True,
             'charset': 'utf8'
         }
 
         opts.update(options)
-
-        if config.env == 'DEV':
-            opts['ssl'] = {}
 
         self.connection = _connect(opts)
         if self.connection is None:

--- a/quasar/northstar_to_user_table.py
+++ b/quasar/northstar_to_user_table.py
@@ -29,8 +29,7 @@ def main():
     # result set. If there aren't, will return false.
     nextPage = True
 
-    ca_settings = {'ca': '/home/quasar/rds-combined-ca-bundle.pem'}
-    db_opts = {'use_unicode': True, 'charset': 'utf8', 'ssl': ca_settings}
+    db_opts = {'use_unicode': True, 'charset': 'utf8'}
     db = Database(db_opts)
 
     def isInt(s):


### PR DESCRIPTION
#### What's this PR do?
Override SSL (don't use SSL) when connecting to MySQL in local development environment

#### Where should the reviewer start?
Just look at code changes

#### How should this be manually tested?
Run locally with an SSL script, e.g. northstar import

#### Any background context you want to provide?
We use SSL in prod but it fails locally. Fixes local dev workflow

#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:


Just a quick little fix. @sheyd please check and merge when you are ready. 