### PR TITLE
2 Bug Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEST_PATH=./
 .PHONY: clean
 
 build:
-	python3 setup.py develop
+	pip3 install --upgrade .
 
 clean:
 	find . -name '*.pyc' -exec rm --force {} +

--- a/quasar/config/__init__.py
+++ b/quasar/config/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from . import dev_priv as config
+from . import dev as config
 
 env = os.environ['ENV']
 


### PR DESCRIPTION
#### What's this PR do?
1. Reverts to using "dev" as the sole file in path to use for DB import.
2. Reverts to pip install step since fixes work on OS X, but requires sudo permission in prod and totally borks the rest of the pathing of other jobs. 

#### Where should the reviewer start?
2 files below.
#### How should this be manually tested?
Checkout and test.
#### Any background context you want to provide?
Eff build bugs and pathing diffs between platforms that make for headaches.

