### PR TITLE
Updated URI field to not use strip_str which removed '/'.

### DIFF
--- a/quasar/campaign_activity.py
+++ b/quasar/campaign_activity.py
@@ -145,7 +145,7 @@ def _process_records(db, rogue_page):
                               strip_str(i['created_at']),
                               strip_str(i['updated_at']),
                               strip_str(j['id']),
-                              strip_str(j['media']['url']),
+                              j['media']['url'],
                               strip_str(j['media']['caption']),
                               strip_str(j['status']),
                               strip_str(j['remote_addr']),


### PR DESCRIPTION
#### What's this PR do?
Updated URI field to not use strip_str which removed '/'. This was causing bad URI's to show up in Looker when people wanted to view Reportback media assets.

#### Where should the reviewer start?
One line/file below.
#### How should this be manually tested?
Checkout branch, and run `campaign_activity_full_backfill` for a few pages, and confirm URI's are fully formed in DB.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/150331377

