### PR TITLE
Updated NS->users ETL to include Facebook_ID.

### DIFF
--- a/quasar/northstar_to_user_table.py
+++ b/quasar/northstar_to_user_table.py
@@ -44,7 +44,8 @@ class NorthstarDB:
                         northstar_created_at_timestamp,\
                         last_logged_in, last_accessed, drupal_uid,\
                         northstar_id_source_name,\
-                        email, mobile, birthdate,\
+                        email, facebook_id,\
+                        mobile, birthdate,\
                         first_name, last_name,\
                         addr_street1, addr_street2,\
                         addr_city, addr_state,\
@@ -54,7 +55,7 @@ class NorthstarDB:
                         moco_current_status,\
                         moco_source_detail)\
                         VALUES(%s,%s,%s,%s,%s,%s,\
-                        %s,%s,%s,%s,\
+                        %s,%s,%s,%s,%s,\
                         %s,%s,%s,%s,\
                         %s,%s,%s,%s,\
                         NULL,NULL,%s,%s,%s)\
@@ -63,7 +64,8 @@ class NorthstarDB:
                         last_logged_in = %s,\
                         last_accessed = %s, drupal_uid = %s,\
                         northstar_id_source_name = %s,\
-                        email = %s, mobile = %s, birthdate = %s,\
+                        email = %s, facebook_id = %s,\
+                        mobile = %s, birthdate = %s,\
                         first_name = %s, last_name = %s,\
                         addr_street1 = %s, addr_street2 = %s,\
                         addr_city = %s, addr_state = %s,\
@@ -79,6 +81,7 @@ class NorthstarDB:
                            strip_str(user['drupal_id']),
                            strip_str(user['source']),
                            strip_str(user['email']),
+                           strip_str(user['facebook_id']),
                            strip_str(user['mobile']),
                            strip_str(user['birthdate']),
                            strip_str(user['first_name']),
@@ -99,6 +102,7 @@ class NorthstarDB:
                            strip_str(user['drupal_id']),
                            strip_str(user['source']),
                            strip_str(user['email']),
+                           strip_str(user['facebook_id']),
                            strip_str(user['mobile']),
                            strip_str(user['birthdate']),
                            strip_str(user['first_name']),


### PR DESCRIPTION
#### What's this PR do?
Includes Facebook ID into Users table.
#### Where should the reviewer start?
One file below.
#### How should this be manually tested?
Run this on local DB to add facebook_id columns:
```
ALTER TABLE users ADD COLUMN facebook_id VARCHAR(255) AFTER email;
ALTER TABLE users_log ADD COLUMN facebook_id VARCHAR(255) AFTER email;
```
Compile package and `northstar_to_quasar_import_backfill {some_hours}` and watch for newly ingested records. 
