### PR TITLE
Update MySQL Port to str in ETL Monitoring

### DIFF
--- a/quasar/etl_monitoring.py
+++ b/quasar/etl_monitoring.py
@@ -17,7 +17,7 @@ class DataFrameDB:
             'host': config.MYSQL_HOST,
             'password': config.MYSQL_PASSWORD,
             'db': config.MYSQL_DATABASE,
-            'port': config.MYSQL_PORT,
+            'port': str(config.MYSQL_PORT),
             'use_unicode': True,
             'charset': 'utf8'
         }


### PR DESCRIPTION
#### What's this PR do?
Updating casting port in ETL monitoring to string since setting string in env breaks other scripts.
#### Where should the reviewer start?
One file below.
#### How should this be manually tested?
Test on dev.
#### Any background context you want to provide?
Implicit cast to string error when just set to int or str.
