### PR TITLE
Slack client sends message per test rather than one big message

### DIFF
--- a/quasar/etl_monitoring.py
+++ b/quasar/etl_monitoring.py
@@ -188,7 +188,7 @@ class ETLMonitoring:
         )
 
     def monitor(self):
-        messages = []
+        sc = SlackClient(config.ETLMON_SLACKBOT_TOKEN)
         frame = self.compile_statuses(self.etl_queries)
         self.write_to_monitoring_table(frame)
 
@@ -196,17 +196,14 @@ class ETLMonitoring:
             this_table = row['table']
             this_desc = row['query']
             this_message = self.compare_latest_values(this_table, this_desc)
-            messages.append(this_message)
-        return messages
+            print(this_message)
+            sc.api_call(
+                "chat.postMessage",
+                channel="#quasar-notifications",
+                text=this_message
+            )
 
 
 def run_monitoring():
     mon = ETLMonitoring()
-    out = mon.monitor()
-
-    sc = SlackClient(config.ETLMON_SLACKBOT_TOKEN)
-    sc.api_call(
-        "chat.postMessage",
-        channel="#quasar-notifications",
-        text=out
-    )
+    mon.monitor()

--- a/quasar/etl_monitoring.py
+++ b/quasar/etl_monitoring.py
@@ -187,8 +187,15 @@ class ETLMonitoring:
             if_exists='append'
         )
 
-    def monitor(self):
+    def send_message(self, message):
         sc = SlackClient(config.ETLMON_SLACKBOT_TOKEN)
+        sc.api_call(
+            "chat.postMessage",
+            channel="#quasar-notifications",
+            text=message
+        )
+
+    def monitor(self):
         frame = self.compile_statuses(self.etl_queries)
         self.write_to_monitoring_table(frame)
 
@@ -196,11 +203,7 @@ class ETLMonitoring:
             this_table = row['table']
             this_desc = row['query']
             this_message = self.compare_latest_values(this_table, this_desc)
-            sc.api_call(
-                "chat.postMessage",
-                channel="#quasar-notifications",
-                text=this_message
-            )
+            self.send_message(this_message)
 
 
 def run_monitoring():

--- a/quasar/etl_monitoring.py
+++ b/quasar/etl_monitoring.py
@@ -196,7 +196,6 @@ class ETLMonitoring:
             this_table = row['table']
             this_desc = row['query']
             this_message = self.compare_latest_values(this_table, this_desc)
-            print(this_message)
             sc.api_call(
                 "chat.postMessage",
                 channel="#quasar-notifications",


### PR DESCRIPTION
#### What's this PR do?
Instead of returning one giant message blob, we will now send a message for each test. This helps with readability. 
