### PR TITLE
Updates queries to NULL insert on no location data.

### DIFF
--- a/quasar/moco_xml_to_quasar.py
+++ b/quasar/moco_xml_to_quasar.py
@@ -1,6 +1,4 @@
-import json
 import os
-import sys
 
 import boto3
 import xmltodict

--- a/quasar/moco_xml_to_quasar.py
+++ b/quasar/moco_xml_to_quasar.py
@@ -1,4 +1,6 @@
+import json
 import os
+import sys
 
 import boto3
 import xmltodict
@@ -15,28 +17,48 @@ db = Database()
 
 
 def _insert_profile(db, profile):
-    str = ''.join(("REPLACE INTO quasar.moco_profile_import ",
-                   "VALUES ({}, '{}', '{}', '{}', '{}', '{}', ",
-                   "'{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', ",
-                   "'{}', '{}', '{}', POINT({}, {}))",
-                   "")).format(profile['@id'],
-                               strip_str(profile['phone_number']),
-                               profile['created_at'], profile['updated_at'],
-                               strip_str(profile['status']),
-                               strip_str(profile['opted_out_at']),
-                               strip_str(profile['opted_out_source']),
-                               strip_str(profile['address']['street1']),
-                               strip_str(profile['address']['street2']),
-                               strip_str(profile['address']['city']),
-                               strip_str(profile['address']['state']),
-                               profile['address']['postal_code'],
-                               strip_str(profile['address']['country']),
-                               strip_str(profile['location']['city']),
-                               strip_str(profile['location']['state']),
-                               profile['location']['postal_code'],
-                               strip_str(profile['location']['country']),
-                               profile['location']['latitude'],
-                               profile['location']['longitude'])
+    if 'location' in profile:
+        str = ''.join(("REPLACE INTO quasar.moco_profile_import ",
+                       "VALUES ({}, '{}', '{}', '{}', '{}', '{}', ",
+                       "'{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', ",
+                       "'{}', '{}', '{}', POINT({}, {}))",
+                       "")).format(profile['@id'],
+                                   strip_str(profile['phone_number']),
+                                   profile['created_at'],
+                                   profile['updated_at'],
+                                   strip_str(profile['status']),
+                                   strip_str(profile['opted_out_at']),
+                                   strip_str(profile['opted_out_source']),
+                                   strip_str(profile['address']['street1']),
+                                   strip_str(profile['address']['street2']),
+                                   strip_str(profile['address']['city']),
+                                   strip_str(profile['address']['state']),
+                                   profile['address']['postal_code'],
+                                   strip_str(profile['address']['country']),
+                                   strip_str(profile['location']['city']),
+                                   strip_str(profile['location']['state']),
+                                   profile['location']['postal_code'],
+                                   strip_str(profile['location']['country']),
+                                   profile['location']['latitude'],
+                                   profile['location']['longitude'])
+    else:
+        str = ''.join(("REPLACE INTO quasar.moco_profile_import ",
+                       "VALUES ({}, '{}', '{}', '{}', '{}', '{}', ",
+                       "'{}', '{}', '{}', '{}', '{}', '{}', '{}', NULL, ",
+                       "NULL, NULL, NULL, POINT(NULL, NULL))",
+                       "")).format(profile['@id'],
+                                   strip_str(profile['phone_number']),
+                                   profile['created_at'],
+                                   profile['updated_at'],
+                                   strip_str(profile['status']),
+                                   strip_str(profile['opted_out_at']),
+                                   strip_str(profile['opted_out_source']),
+                                   strip_str(profile['address']['street1']),
+                                   strip_str(profile['address']['street2']),
+                                   strip_str(profile['address']['city']),
+                                   strip_str(profile['address']['state']),
+                                   profile['address']['postal_code'],
+                                   strip_str(profile['address']['country']))
     db.query(str)
 
 


### PR DESCRIPTION
#### What's this PR do?
If no location data exists in a profile, it ensures the query to the relevant `loc_*` DB fields are NULL'd.
#### Where should the reviewer start?
One file below.
#### How should this be manually tested?
Checkout branch, pull down some MoCo Profiles locally, and iterate over the test set.
#### Any background context you want to provide?
I hate putting the if check clause in the `_import_record` function, since I think it's cleaner to add blank profile fields into the original array, but it's less efficient, and also I was getting lost in subkey dict rabbit hole syntax.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/151412624

