### PR TITLE
Phoenix Next Queue Cleanup.

### DIFF
--- a/quasar/phoenix_next_queue_cleanup.py
+++ b/quasar/phoenix_next_queue_cleanup.py
@@ -1,0 +1,22 @@
+import time
+
+from .queue import QuasarQueue
+
+
+class PhoenixNextCleanupQueue(QuasarQueue):
+
+    def process_message(self, message_data):
+        try:
+            event_type = message_data['data']['event_type']
+            print("It's a C.IO event, republishing {}!".format(message_data['data']['event_id']))
+            time.sleep(0.01)
+            self.pub_message(message_data)
+        except KeyError:
+            print("Phoenix-next event, acking!")
+
+
+queue = PhoenixNextCleanupQueue()
+
+
+def main():
+    queue.start_consume()

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
             'northstar_to_quasar_import = quasar.northstar_to_user_table:full_backfill',
             'northstar_to_quasar_import_backfill = quasar.northstar_to_user_table:backfill_since',
             'quasar_blink_queue_consumer = quasar.customerio:main',
+            'phoenix_next_cleanup = quasar.phoenix_next_queue_cleanup:main',
             'regenerate_mobile_master_lookup_lite_table = quasar.create_mobile_master_lookup_lite:main',
             'runscope_cleanup = quasar.cio_runscope_queue_cleanup:main',
             'scrape_moco_profiles = quasar.moco_scraper:start_profile_scrape',


### PR DESCRIPTION
#### What's this PR do?
Cleans up non-cio events in quasar-blink queue. In this case, to remove Phoenix Next objects that were accidentally introduced to queue.
#### Where should the reviewer start?
One file below.
#### How should this be manually tested?
Tested in Dev and Prod.

