### PR TITLE
Adding basic sleep timer to improve pagination performance.

### DIFF
--- a/quasar/campaign_activity.py
+++ b/quasar/campaign_activity.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import time
 
 from .config import config
 from .utils import strip_str, now_minus_hours
@@ -50,6 +51,7 @@ def _backfill(hours=None):
         if hours is None:
             _update_progress(db, current_page)
         current_page += 1
+        time.sleep(0.1)
         page = scraper.getJson('', params={'page': current_page})
 
     # Cleanup


### PR DESCRIPTION
#### What's this PR do?
Adds basic sleep timer to Rogue ingestion from campaign activity table.
#### Where should the reviewer start?
One file below.
#### How should this be manually tested?
Tested on dev.
#### Any background context you want to provide?
Last upgrade to use `cursor` works well, but hammers the DB to a halt after about 13K pages.

