### PR TITLE
Bash script for importing Puck to Quasar Postgres DB via ToroDB

### DIFF
--- a/quasar/misc/puck-to-quasar-pg.sh
+++ b/quasar/misc/puck-to-quasar-pg.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Remove Old Backup
+echo "Deleting old Puck mongo backup."
+/bin/rm -rf /var/tmp/puck-mongo-dump
+echo "Old Puck mongo backup deleted."
+
+# Source Env Variables and Dump Puck DB
+source ~/.mongorc.js
+mongodump -h $PUCK_DB:$PUCK_PORT -d $PUCK_AUTH_DB -u $PUCK_USER -p $PUCK_PASS -o /var/tmp/puck-mongo-dump
+echo "Puck mongo backup complete."
+
+# Restore to internal mongo cluster.
+echo "Restoring Puck dump to internal mongo cluster."
+mongorestore --drop -h mongo1.d12g.co /var/tmp/puck-mongo-dump
+
+# ToroDB Stampede to Quasar PostgreSQL DB
+sudo torodb-stampede &
+
+# Sleep for 10 mins to allow for full sync
+echo "Waiting for ToroDB sync to finish."
+for i in {1..600}
+do
+  echo "Been asleep for $i seconds."
+  sleep 1
+done
+
+# Kill ToroDB Sync
+echo "Killing ToroDB processes."
+sudo /usr/bin/pkill -f torodb-stampede
+
+# Refreshing Puck Postgres DB Tables
+echo "Refreshing Puck derived tables."
+/usr/bin/psql -h quasar-pg.c9ajz690mens.us-east-1.rds.amazonaws.com -U torodb quasar -a -f puck-etl.sql
+sheydari@quasar-jump:~$ cat puck-to-quasar-pg.sh 
+#!/bin/bash
+
+# Remove Old Backup
+echo "Deleting old Puck mongo backup."
+/bin/rm -rf /var/tmp/puck-mongo-dump
+echo "Old Puck mongo backup deleted."
+
+# Source Env Variables and Dump Puck DB
+source ~/.mongorc.js
+mongodump -h $PUCK_DB:$PUCK_PORT -d $PUCK_AUTH_DB -u $PUCK_USER -p $PUCK_PASS -o /var/tmp/puck-mongo-dump
+echo "Puck mongo backup complete."
+
+# Restore to internal mongo cluster.
+echo "Restoring Puck dump to internal mongo cluster."
+mongorestore --drop -h mongo1.d12g.co /var/tmp/puck-mongo-dump
+
+# ToroDB Stampede to Quasar PostgreSQL DB
+sudo torodb-stampede &
+
+# Sleep for 10 mins to allow for full sync
+echo "Waiting for ToroDB sync to finish."
+for i in {1..600}
+do
+  echo "Been asleep for $i seconds."
+  sleep 1
+done
+
+# Kill ToroDB Sync
+echo "Killing ToroDB processes."
+sudo /usr/bin/pkill -f torodb-stampede
+
+# Refreshing Puck Postgres DB Tables
+echo "Refreshing Puck derived tables."
+/usr/bin/psql -h quasar-pg.c9ajz690mens.us-east-1.rds.amazonaws.com -U torodb quasar -a -f puck-etl.sql


### PR DESCRIPTION
#### What's this PR do?
Adds bash script used on Quasar bastion node to refresh data from Puck MongoDB backend into internal Mongo cluster that then pushes to Quasar PostgreSQL DB using ToroDB Stampede.

#### Where should the reviewer start?
One file below.
#### How should this be manually tested?
It's live and tested on Prod, and running.
#### Any background context you want to provide?
This is a stop-gap measure till we have queue consumption running for PN.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/151770344

