### PR TITLE
Adding details for signup source from Rogue.

### DIFF
--- a/quasar/campaign_activity.py
+++ b/quasar/campaign_activity.py
@@ -92,6 +92,7 @@ def _process_records(db, rogue_page):
                               quantity = %s,\
                               why_participated = %s,\
                               signup_source = %s,\
+                              signup_details = %s,\
                               signup_created_at = %s,\
                               signup_updated_at = %s,\
                               post_id = -1,\
@@ -108,6 +109,7 @@ def _process_records(db, rogue_page):
                           strip_str(i['quantity']),
                           strip_str(i['why_participated']),
                           strip_str(i['signup_source']),
+                          strip_str(i['details']),
                           strip_str(i['created_at']),
                           strip_str(i['updated_at'])))
         else:
@@ -121,6 +123,7 @@ def _process_records(db, rogue_page):
                                   quantity = %s,\
                                   why_participated = %s,\
                                   signup_source = %s,\
+                                  signup_details = %s,\
                                   signup_created_at = %s,\
                                   signup_updated_at = %s,\
                                   post_id = %s,\
@@ -138,6 +141,7 @@ def _process_records(db, rogue_page):
                               strip_str(i['quantity']),
                               strip_str(i['why_participated']),
                               strip_str(i['signup_source']),
+                              strip_str(i['details']),
                               strip_str(i['created_at']),
                               strip_str(i['updated_at']),
                               strip_str(j['id']),


### PR DESCRIPTION
#### What's this PR do?
Adds details about signups from Rogue as `signup_details` on campaign_info table in Quasar DB.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/rogue-details?expand=1#diff-0b03649b386ffaed2898b4f486b7ec1e
#### How should this be manually tested?
Checkout branch, bring up Vagrant, refresh schema, and run two following commands:
```
ALTER TABLE campaign_activity ADD COLUMN signup_details VARCHAR(32) AFTER signup_source;
ALTER TABLE campaign_activity_log ADD COLUMN signup_details VARCHAR(32) AFTER signup_source;
```

Do a backfill diff from Rogue and examine records.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/152153786
