### PR TITLE
Using MongoDB localhost instead of full cluster.

### DIFF
--- a/quasar/misc/puck-to-quasar-pg.sh
+++ b/quasar/misc/puck-to-quasar-pg.sh
@@ -12,7 +12,7 @@ echo "Puck mongo backup complete."
 
 # Restore to internal mongo cluster.
 echo "Restoring Puck dump to internal mongo cluster."
-mongorestore --drop -h mongo2.d12g.co /var/tmp/puck-mongo-dump
+mongorestore --drop /var/tmp/puck-mongo-dump
 
 # ToroDB Stampede to Quasar PostgreSQL DB
 sudo torodb-stampede &


### PR DESCRIPTION
#### What's this PR do?
Uses localhost mongo sourcing for ToroDB instead of external cluster.

