### PR TITLE
Adding x-max-priority to queue declaration.

### DIFF
--- a/quasar/queue.py
+++ b/quasar/queue.py
@@ -31,7 +31,8 @@ class QuasarQueue:
         self.connection = pika.BlockingConnection(self.params)
         self.channel = self.connection.channel()
         self.channel.basic_qos(prefetch_count=config.QUEUE_PREFETCH_COUNT)
-        self.channel.queue_declare(amqp_queue, durable=True)
+        self.channel.queue_declare(amqp_queue, durable=True, 
+                                   arguments={'x-max-priority' : 2})
 
         self.amqp_uri = amqp_uri
         self.amqp_exchange = amqp_exchange

--- a/quasar/queue.py
+++ b/quasar/queue.py
@@ -31,8 +31,8 @@ class QuasarQueue:
         self.connection = pika.BlockingConnection(self.params)
         self.channel = self.connection.channel()
         self.channel.basic_qos(prefetch_count=config.QUEUE_PREFETCH_COUNT)
-        self.channel.queue_declare(amqp_queue, durable=True, 
-                                   arguments={'x-max-priority' : 2})
+        self.channel.queue_declare(amqp_queue, durable=True,
+                                   arguments={'x-max-priority': 2})
 
         self.amqp_uri = amqp_uri
         self.amqp_exchange = amqp_exchange


### PR DESCRIPTION
#### What's this PR do?
Blink added priority functionality to queues. As the default is `2`, it's necessary to define the priority variable for the Quasar queue, as the default of `None` returns an error.
#### Where should the reviewer start?
One file below.
#### How should this be manually tested?
Checkout and run using `runscope_cleanup` test script.
#### Any background context you want to provide?
First PR of 2018!
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/154184866

