### PR TITLE
Updating ToroDB sync allowance to 20 minutes instead of 10.

### DIFF
--- a/quasar/misc/puck-to-quasar-pg.sh
+++ b/quasar/misc/puck-to-quasar-pg.sh
@@ -19,7 +19,7 @@ sudo torodb-stampede &
 
 # Sleep for 10 mins to allow for full sync
 echo "Waiting for ToroDB sync to finish."
-for i in {1..600}
+for i in {1..1200}
 do
   echo "Been asleep for $i seconds."
   sleep 1


### PR DESCRIPTION
#### What's this PR do?
Ups TTL to 20 minutes for ToroDB Stampede Sync of import to PostgreSQL for Puck/PN events.

#### Where should the reviewer start?
One file below.
#### How should this be manually tested?
Testing it on compute node.
#### Any background context you want to provide?
10 minutes used to be enough, now needs longer.

