### PR TITLE
Make queue variables required and more explicit in definition.

### DIFF
--- a/quasar/cio_queue_process.py
+++ b/quasar/cio_queue_process.py
@@ -1,5 +1,6 @@
 import json
 
+from .config import config
 from .database import Database
 from .queue import QuasarQueue
 from .utils import unixtime_to_isotime as u2i

--- a/quasar/cio_queue_process.py
+++ b/quasar/cio_queue_process.py
@@ -11,6 +11,10 @@ db = Database()
 
 class CioQueue(QuasarQueue):
 
+    def __init__(self):
+        super(CioQueue, self).__init__(config.AMQP_URI, config.BLINK_QUEUE,
+                                       config.BLINK_EXCHANGE)
+
     def process_message(self, message_data):
         print(''.join(("Processing C.IO event id: "
                        "{}.")).format(message_data['data']['event_id']))

--- a/quasar/cio_runscope_queue_cleanup.py
+++ b/quasar/cio_runscope_queue_cleanup.py
@@ -1,7 +1,13 @@
+from .config import config
 from .queue import QuasarQueue
 
 
 class RunscopeQueue(QuasarQueue):
+
+    def __init__(self):
+        super(RunscopeQueue, self).__init__(config.AMQP_URI,
+                                            config.BLINK_QUEUE,
+                                            config.BLINK_EXCHANGE)
 
     def process_message(self, message_data):
         email = message_data['data']['data']['email_address']

--- a/quasar/queue.py
+++ b/quasar/queue.py
@@ -21,10 +21,7 @@ class QuasarQueue:
     by children classes to specify exactly how to handle each message.
     """
 
-    def __init__(self,
-                 amqp_uri=config.AMQP_URI,
-                 amqp_queue=config.AMQP_QUEUE,
-                 amqp_exchange=config.AMQP_EXCHANGE):
+    def __init__(self, amqp_uri, amqp_queue, amqp_exchange):
         """Setup MySQL and AMQP connections and credentials."""
         self.params = pika.URLParameters(amqp_uri)
         self.params.socket_timeout = 5


### PR DESCRIPTION
#### What's this PR do?
* Remove default config file values for base queue class, since we're defining multiple queue/consumers in future ETL scripts.
* Update C.IO consumer to use new explicit variable values based on new queue class.
#### Where should the reviewer start?
Three files changed below.
#### How should this be manually tested?
Checkout code locally and test c.io runscope cleanup script.

#### Any background context you want to provide?
We've always defaulted to processing from a single queue. We're moving towards more advanced use cases for queue and message parsing, and need to abstract away more config values to enable the queue class to serve multiple consumers/publishers.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/154369417

