### PR TITLE
Script to load legacy reportback .csv into quasar

### DIFF
--- a/quasar/reportback_asterisk.py
+++ b/quasar/reportback_asterisk.py
@@ -1,0 +1,36 @@
+import sys
+import os
+import pandas as pd
+
+from .config import config
+from .utils import QuasarException
+from .etl_monitoring import DataFrameDB
+from sqlalchemy import create_engine
+
+
+class LoadReportback:
+    def __init__(self):
+        db_opts = {}
+        self.db = DataFrameDB(db_opts)
+
+    def read_csv(self):
+        df = pd.read_csv("quasar/misc/reportbacks_asterisk.csv")
+        return df
+
+    def load_csv(self, df):
+        df.to_sql(
+            name='legacy_reportbacks',
+            con=self.db.engine,
+            schema='playpen',
+            if_exists='replace',
+            index=False
+        )
+
+    def read_load(self):
+        df = self.read_csv()
+        self.load_csv(df)
+
+
+def run_load_reportbacks():
+    rb = LoadReportback()
+    rb.read_load()

--- a/quasar/reportback_asterisk.py
+++ b/quasar/reportback_asterisk.py
@@ -1,11 +1,6 @@
-import sys
-import os
 import pandas as pd
 
-from .config import config
-from .utils import QuasarException
 from .etl_monitoring import DataFrameDB
-from sqlalchemy import create_engine
 
 
 class LoadReportback:

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             'phoenix_next_cleanup = quasar.phoenix_next_queue_cleanup:main',
             'regenerate_mobile_master_lookup_lite_table = quasar.create_mobile_master_lookup_lite:main',
             'runscope_cleanup = quasar.cio_runscope_queue_cleanup:main',
+            'reportbacks_asterisk = quasar.reportback_asterisk:run_load_reportbacks',
             'scrape_moco_profiles = quasar.moco_scraper:start_profile_scrape',
             'scrape_moco_messages = quasar.moco_scraper:start_message_scrape',
             'update_mobile = quasar.jc_update_mobile:main',


### PR DESCRIPTION
#### What's this PR do?
- Creates a simple class to load a .csv into a table in quasar-mysql

#### Where should the reviewer start?
- reportback_asterisk.py

#### How should this be manually tested?
- Are there values in the playpen.legacy_reportbacks table?
#### Any background context you want to provide?
- This is a band-aid solution to getting reportbacks outside of rogue into quasar and looker. It can be discontinued once the data is flowing through the correct rogue pipelines

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/154480468

#### Screenshots (if appropriate)
#### Questions:
