### PR TITLE
Remove sms_game_log from member_event_log build

### DIFF
--- a/quasar/member_event_log.py
+++ b/quasar/member_event_log.py
@@ -102,17 +102,8 @@ class MemberEventLog:
                 "7" AS 'action_id',
                 u.source AS 'source',
                 u.northstar_id AS 'action_serial_id'
-            FROM quasar.users u
-            UNION ALL
-            SELECT ### sms game log ###
-                qu.northstar_id AS 'northstar_id',
-                sgl.timestamp AS 'timestamp',
-                sgl.action AS 'action',
-                sgl.action_id AS 'action_id',
-                NULL AS 'source',
-                "0" AS 'action_serial_id'
-            FROM sms_game_log sgl
-            LEFT JOIN quasar.users qu on qu.drupal_uid = sgl.uid) AS a);"""
+            FROM quasar.users u) AS a)
+        ORDER BY a.timestamp asc;"""
         self.db.query(mel_query)
 
     def sequence(self):


### PR DESCRIPTION
#### What's this PR do?
Removes sms_game_log records from member_event_log

#### Where should the reviewer start?
member_event_log.py

#### How should this be manually tested?
Run the query

#### Any background context you want to provide?
With sms game signups imported into rogue, additional game log tables/records are now redundant

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/154880382

