### PR TITLE
Reversing array so time backfill starts from earliest time to current.

### DIFF
--- a/quasar/northstar_to_user_table_pg.py
+++ b/quasar/northstar_to_user_table_pg.py
@@ -128,6 +128,7 @@ def _backfill(hours_ago=None):
         intervals = [_interval(hour) for hour in range(
             int(hours_ago) + 1) if hour > 0]
 
+        intervals.reverse()
         for start, end in intervals:
             create_params = {'after[created_at]': str(
                 start), 'before[created_at]': str(end)}


### PR DESCRIPTION
#### What's this PR do?
1. Updates Northstar backfill for Postgres to start at beginning backfill time instead of going backwards from now to start runtime.

#### Where should the reviewer start?
One file below.
#### How should this be manually tested?
Checkout on local vagrant, check parsing output on an NS backfill to ensure date ranges are from beginning of backfill diff range.
#### Any background context you want to provide?
When we resume backfills, we want to specify from time forwards, not backwards to make sure we get records filled from last date time to now, not vice versa.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/155534487

