### PR TITLE
Updated SQL syntax to accommodate new primary key.

### DIFF
--- a/quasar/northstar_to_user_table_pg.py
+++ b/quasar/northstar_to_user_table_pg.py
@@ -44,39 +44,9 @@ class NorthstarDB:
                                    "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,"
                                    "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,"
                                    "%s,%s,%s,%s,%s,%s,%s,%s,%s) "
-                                   "ON CONFLICT (id) DO UPDATE "
-                                   "SET (id, first_name, last_name, "
-                                   "last_initial, photo, email, mobile, "
-                                   "facebook_id, interests, birthdate, "
-                                   "addr_street1, addr_street2, "
-                                   "addr_city, addr_state, addr_zip, "
-                                   "addr_source, source, source_detail, "
-                                   "slack_id, sms_status, sms_paused, "
-                                   "language, country, drupal_id, "
-                                   "role, last_accessed_at, "
-                                   "last_authenticated_at, "
-                                   "last_messaged_at, updated_at, "
-                                   "created_at) = "
-                                   "(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,"
-                                   "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,"
-                                   "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")),
+                                   "ON CONFLICT (id, created_at, updated_at)"
+                                   " DO NOTHING")),
                           (user['id'], user['first_name'],
-                           user['last_name'], user['last_initial'],
-                           user['photo'], user['email'], user['mobile'],
-                           user['facebook_id'], user['interests'],
-                           user['birthdate'], user['addr_street1'],
-                           user['addr_street2'], user['addr_city'],
-                           user['addr_state'], user['addr_zip'],
-                           user['addr_source'], user['source'],
-                           user['source_detail'], user['slack_id'],
-                           user['sms_status'], user['sms_paused'],
-                           user['language'], user['country'],
-                           user['drupal_id'], user['role'],
-                           user['last_accessed_at'],
-                           user['last_authenticated_at'],
-                           user['last_messaged_at'],
-                           user['updated_at'], user['created_at'],
-                           user['id'], user['first_name'],
                            user['last_name'], user['last_initial'],
                            user['photo'], user['email'], user['mobile'],
                            user['facebook_id'], user['interests'],


### PR DESCRIPTION
#### What's this PR do?
* Updates Northstar Postgres data pipeline to accommodate duplicate records for backfills without erroring out.
#### Where should the reviewer start?
One file below.
#### How should this be manually tested?
Checkout to local, and update primary key on `northstar.users` to be (id, created_at, updated_at) and do a backfill from NS Staging.
#### Any background context you want to provide?
We're doing away with `_log` tables in Postgres, so raw tables will have multiple records, based on `updated_at` updates.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/155822507

