### PR TITLE
Queue updates to write to dedicated Rogue Postgres queue, along with Rogue.

### DIFF
--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -12,15 +12,17 @@ from .utils import strip_str
 class CioQueue(QuasarQueue):
 
     def __init__(self):
-        super(CioQueue, self).__init__(config.AMQP_URI, config.BLINK_QUEUE,
+        super().__init__(config.AMQP_URI, config.BLINK_QUEUE,
                                        config.BLINK_EXCHANGE)
         self.rogue_queue = RogueQueue()
+        self.rogue_pg_queue = RoguePostgresQueue()
         self.db = Database()
 
     def process_message(self, message_data):
         if pydash.get(message_data, 'data.meta.message_source') == 'rogue':
             print("Routing message to Rogue queue.")
             self.rogue_queue.pub_message(message_data)
+            self.rogue_pg_queue.pub_message(message_data)
         else:
             print(''.join(("Processing C.IO event id: "
                            "{}.")).format(message_data['data']['event_id']))
@@ -74,7 +76,7 @@ class CioQueue(QuasarQueue):
 class RogueQueue(QuasarQueue):
 
     def __init__(self):
-        super(RogueQueue, self).__init__(config.AMQP_URI, config.ROGUE_QUEUE,
+        super().__init__(config.AMQP_URI, config.ROGUE_QUEUE,
                                          config.QUASAR_EXCHANGE)
         self.db = Database()
         self.campaign_activity_table = config.CAMPAIGN_ACTIVITY_TABLE
@@ -275,3 +277,9 @@ class RogueQueue(QuasarQueue):
         else:
             print("Unknown rogue message type. Exiting.")
             sys.exit(1)
+
+class RoguePostgresQueue(QuasarQueue):
+
+    def __init__(self):
+        super().__init__(config.AMQP_URI, config.ROGUE_PG_QUEUE,
+                                         config.QUASAR_EXCHANGE)

--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -13,7 +13,7 @@ class CioQueue(QuasarQueue):
 
     def __init__(self):
         super().__init__(config.AMQP_URI, config.BLINK_QUEUE,
-                                       config.BLINK_EXCHANGE)
+                         config.BLINK_EXCHANGE)
         self.rogue_queue = RogueQueue()
         self.rogue_pg_queue = RoguePostgresQueue()
         self.db = Database()
@@ -77,7 +77,7 @@ class RogueQueue(QuasarQueue):
 
     def __init__(self):
         super().__init__(config.AMQP_URI, config.ROGUE_QUEUE,
-                                         config.QUASAR_EXCHANGE)
+                         config.QUASAR_EXCHANGE)
         self.db = Database()
         self.campaign_activity_table = config.CAMPAIGN_ACTIVITY_TABLE
         self.campaign_activity_log_table = config.CAMPAIGN_ACTIVITY_LOG_TABLE
@@ -278,8 +278,9 @@ class RogueQueue(QuasarQueue):
             print("Unknown rogue message type. Exiting.")
             sys.exit(1)
 
+
 class RoguePostgresQueue(QuasarQueue):
 
     def __init__(self):
         super().__init__(config.AMQP_URI, config.ROGUE_PG_QUEUE,
-                                         config.QUASAR_EXCHANGE)
+                         config.QUASAR_EXCHANGE)


### PR DESCRIPTION
#### What's this PR do?
* Copies messages to `quasar.rogue-pg` queue, so we can have a copy to use with dedicated Rogue PG Consumer.
* Updated `super()` call to be more Python 3'esque.

#### Where should the reviewer start?
One file below.
#### How should this be manually tested?
* Tested on staging. `quasar.rogue-pg` queue created. CIO queue consumed with messages, and all messages copied to both `quasar.rogue` and `quasar.rogue-pg` queue.
#### Any background context you want to provide?
As part of MySQL -> Postgres migration, we need to fundamentally consume events to a different schema, so need dedicated queue to ingest records from.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/155913083
