### PR TITLE
Rogue Postgres Consumer

### DIFF
--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -361,7 +361,7 @@ class RoguePostgresQueue(QuasarQueue):
                                    "(id, created_at, updated_at, "
                                    "status, deleted_at) VALUES "
                                    "(%s,%s,%s,%s,%s)")),
-                          (post_id, created_at[0], deleted_at, 
+                          (post_id, created_at[0], deleted_at,
                            'deleted', deleted_at))
 
     def _add_post_details(self, post_id, post_details):
@@ -439,7 +439,7 @@ class RoguePostgresQueue(QuasarQueue):
                         pydash.get(data, 'details') == ''):
                     pass
                 else:
-                    self._add_post_details(data['id'], data['details'])                
+                    self._add_post_details(data['id'], data['details'])
         else:
             print("Unknown rogue message type. Exiting.")
             sys.exit(1)

--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -313,12 +313,13 @@ class RoguePostgresQueue(QuasarQueue):
         # Get created_at date of signup.
         created_at = self.db.query_str(''.join(("SELECT created_at "
                                                 "FROM rogue.signups WHERE "
-                                                "id = %s")),
-                                       signup_id)
+                                                "id = '%s'")),
+                                       (signup_id,))
+        print("Created at is {}".format(created_at[0]))
         self.db.query_str(''.join(("INSERT INTO rogue.signups "
                                    "(id, created_at, updated_at, "
                                    "deleted_at) VALUES "
-                                   "(%s,%s,%s,%s")),
+                                   "(%s,%s,%s,%s)")),
                           (signup_id, created_at[0], deleted_at, deleted_at))
         print("Signup {} deleted and archived.".format(signup_id))
 
@@ -331,7 +332,8 @@ class RoguePostgresQueue(QuasarQueue):
                                    "remote_addr, created_at, "
                                    "updated_at) VALUES "
                                    "(%s,%s,%s,%s,%s,%s,%s,%s,%s,"
-                                   "%s,%s,%s,%s,%s,%s,%s,)")),
+                                   "%s,%s,%s,%s,%s,%s,%s) ON CONFLICT "
+                                   "DO NOTHING")),
                           (post_data['id'],
                            post_data['signup_id'],
                            post_data['campaign_id'],
@@ -344,7 +346,7 @@ class RoguePostgresQueue(QuasarQueue):
                            post_data['media']['caption'],
                            post_data['status'],
                            post_data['source'],
-                           post_data['signup_source']
+                           post_data['signup_source'],
                            post_data['remote_addr'],
                            post_data['created_at'],
                            post_data['updated_at']))
@@ -354,8 +356,8 @@ class RoguePostgresQueue(QuasarQueue):
         # Get created_at timestamp of post.
         created_at = self.db.query_str(''.join(("SELECT created_at "
                                                 "FROM rogue.posts WHERE "
-                                                "id = %s")),
-                                       post_id)
+                                                "id = '%s'")),
+                                       (post_id,))
         # Set post status to 'deleted'.
         self.db.query_str(''.join(("INSERT INTO rogue.posts "
                                    "(id, created_at, updated_at, "
@@ -378,7 +380,7 @@ class RoguePostgresQueue(QuasarQueue):
                                        "voter_registration_status, "
                                        "voter_registration_source, "
                                        "voter_registration_method, "
-                                       "voting_method_preference, "
+                                       "voter_registration_preference, "
                                        "email_subscribed, sms_subscribed) "
                                        " VALUES (%s,%s,%s,%s,%s,%s,%s,%s,"
                                        "%s,%s,%s,%s,%s) ON CONFLICT "
@@ -404,9 +406,9 @@ class RoguePostgresQueue(QuasarQueue):
                                        "voter_registration_status, "
                                        "voter_registration_source, "
                                        "voter_registration_method, "
-                                       "voting_method_preference, "
+                                       "voter_registration_preference, "
                                        "email_subscribed, sms_subscribed) "
-                                       " VALUES (%s,%s,%s,%s,%s,%s,%s,%s,"
+                                       " VALUES (%s,%s,%s,%s,%s,%s,%s,"
                                        "%s,%s,%s,%s,%s) ON CONFLICT "
                                        "DO NOTHING")),
                               (post_id,

--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -4,6 +4,7 @@ import sys
 
 from .config import config
 from .database import Database
+from .database_pg import Database as DatabasePG
 from .queue import QuasarQueue
 from .utils import unixtime_to_isotime as u2i
 from .utils import strip_str
@@ -284,3 +285,161 @@ class RoguePostgresQueue(QuasarQueue):
     def __init__(self):
         super().__init__(config.AMQP_URI, config.ROGUE_PG_QUEUE,
                          config.QUASAR_EXCHANGE)
+        self.db = DatabasePG()
+
+    def _add_signup(self, signup_data):
+        self.db.query_str(''.join(("INSERT INTO rogue.signups "
+                                   "(id, northstar_id, campaign_id, "
+                                   "campaign_run_id, quantity, "
+                                   "why_participated, source, details, "
+                                   "created_at, updated_at) "
+                                   "VALUES (%s,%s,%s,%s,%s,%s,"
+                                   "%s,%s,%s,%s) ON CONFLICT "
+                                   "(id, created_at, updated_at) "
+                                   "DO NOTHING")),
+                          (signup_data['signup_id'],
+                           signup_data['northstar_id'],
+                           signup_data['campaign_id'],
+                           signup_data['campaign_run_id'],
+                           signup_data['quantity'],
+                           signup_data['why_participated'],
+                           signup_data['signup_source'],
+                           signup_data['details'],
+                           signup_data['created_at'],
+                           signup_data['updated_at']))
+        print("Signup {} ETL'd.".format(signup_data['signup_id']))
+
+    def _delete_signup(self, signup_id, deleted_at):
+        # Get created_at date of signup.
+        created_at = self.db.query_str(''.join(("SELECT created_at "
+                                                "FROM rogue.signups WHERE "
+                                                "id = %s")),
+                                       signup_id)
+        self.db.query_str(''.join(("INSERT INTO rogue.signups "
+                                   "(id, created_at, updated_at, "
+                                   "deleted_at) VALUES "
+                                   "(%s,%s,%s,%s")),
+                          (signup_id, created_at[0], deleted_at, deleted_at))
+        print("Signup {} deleted and archived.".format(signup_id))
+
+    def _add_post(self, post_data):
+        self.db.query_str(''.join(("INSERT INTO rogue.posts "
+                                   "(id, signup_id, campaign_id, "
+                                   "campaign_run_id, northstar_id, "
+                                   "type, action, quantity, url, caption, "
+                                   "status, source, signup_source, "
+                                   "remote_addr, created_at, "
+                                   "updated_at) VALUES "
+                                   "(%s,%s,%s,%s,%s,%s,%s,%s,%s,"
+                                   "%s,%s,%s,%s,%s,%s,%s,)")),
+                          (post_data['id'],
+                           post_data['signup_id'],
+                           post_data['campaign_id'],
+                           post_data['campaign_run_id'],
+                           post_data['northstar_id'],
+                           post_data['type'],
+                           post_data['action'],
+                           post_data['quantity'],
+                           post_data['media']['url'],
+                           post_data['media']['caption'],
+                           post_data['status'],
+                           post_data['source'],
+                           post_data['signup_source']
+                           post_data['remote_addr'],
+                           post_data['created_at'],
+                           post_data['updated_at']))
+        print("Post {} ETL'd.".format(post_data['id']))
+
+    def _delete_post(self, post_id, deleted_at):
+        # Get created_at timestamp of post.
+        created_at = self.db.query_str(''.join(("SELECT created_at "
+                                                "FROM rogue.posts WHERE "
+                                                "id = %s")),
+                                       post_id)
+        # Set post status to 'deleted'.
+        self.db.query_str(''.join(("INSERT INTO rogue.posts "
+                                   "(id, created_at, updated_at, "
+                                   "status, deleted_at) VALUES "
+                                   "(%s,%s,%s,%s,%s)")),
+                          (post_id, created_at[0], deleted_at, 
+                           'deleted', deleted_at))
+
+    def _add_post_details(self, post_id, post_details):
+        # TODO: Remove type check if Rogue sends this as JSON/dict.
+        if type(post_details) is str:
+            details = json.loads(post_details)
+        else:
+            details = post_details
+        if pydash.get(details, 'source_details'):
+            self.db.query_str(''.join(("INSERT INTO rogue.post_details "
+                                       "(post_id, hostname, referral_code, "
+                                       "partner_comms_opt_in, created_at, "
+                                       "updated_at, source_details, "
+                                       "voter_registration_status, "
+                                       "voter_registration_source, "
+                                       "voter_registration_method, "
+                                       "voting_method_preference, "
+                                       "email_subscribed, sms_subscribed) "
+                                       " VALUES (%s,%s,%s,%s,%s,%s,%s,%s,"
+                                       "%s,%s,%s,%s,%s) ON CONFLICT "
+                                       "DO NOTHING")),
+                              (post_id,
+                               details['hostname'],
+                               details['referral-code'],
+                               details['partner-comms-opt-in'],
+                               details['created-at'],
+                               details['updated-at'],
+                               details['source_details'],
+                               details['voter-registration-status'],
+                               details['voter-registration-source'],
+                               details['voter-registration-method'],
+                               details['voting-method-preference'],
+                               details['email subscribed'],
+                               details['sms subscribed']))
+        else:
+            self.db.query_str(''.join(("INSERT INTO rogue.post_details "
+                                       "(post_id, hostname, referral_code, "
+                                       "partner_comms_opt_in, created_at, "
+                                       "updated_at, "
+                                       "voter_registration_status, "
+                                       "voter_registration_source, "
+                                       "voter_registration_method, "
+                                       "voting_method_preference, "
+                                       "email_subscribed, sms_subscribed) "
+                                       " VALUES (%s,%s,%s,%s,%s,%s,%s,%s,"
+                                       "%s,%s,%s,%s,%s) ON CONFLICT "
+                                       "DO NOTHING")),
+                              (post_id,
+                               details['hostname'],
+                               details['referral-code'],
+                               details['partner-comms-opt-in'],
+                               details['created-at'],
+                               details['updated-at'],
+                               details['voter-registration-status'],
+                               details['voter-registration-source'],
+                               details['voter-registration-method'],
+                               details['voting-method-preference'],
+                               details['email subscribed'],
+                               details['sms subscribed']))
+        print("Details for post {} ETL'd.".format(post_id))
+
+    def process_message(self, message_data):
+        data = message_data['data']
+        if data['meta']['type'] == 'signup':
+            if pydash.get(data, 'deleted_at'):
+                self._delete_signup(data['id'], data['deleted_at'])
+            else:
+                self._add_signup(data)
+        elif data['meta']['type'] == 'post':
+            if pydash.get(data, 'deleted_at'):
+                self._delete_post(data['id'], data['deleted_at'])
+            else:
+                self._add_post(data)
+                if (pydash.get(data, 'details') is None or
+                        pydash.get(data, 'details') == ''):
+                    pass
+                else:
+                    self._add_post_details(data['id'], data['details'])                
+        else:
+            print("Unknown rogue message type. Exiting.")
+            sys.exit(1)

--- a/quasar/rogue_consumer_pg.py
+++ b/quasar/rogue_consumer_pg.py
@@ -1,0 +1,8 @@
+from .quasar_queue import RoguePostgresQueue
+
+
+queue = RoguePostgresQueue()
+
+
+def main():
+    queue.start_consume()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="0.3.0",
+    version="0.4.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
             'phoenix_next_cleanup = quasar.phoenix_next_queue_cleanup:main',
             'regenerate_mobile_master_lookup_lite_table = quasar.create_mobile_master_lookup_lite:main',
             'rogue_consume = quasar.rogue_consumer:main',
+            'rogue_consume_pg = quasar.rogue_consumer_pg:main',
             'runscope_cleanup = quasar.cio_runscope_queue_cleanup:main',
             'reportbacks_asterisk = quasar.reportback_asterisk:run_load_reportbacks',
             'scrape_moco_profiles = quasar.moco_scraper:start_profile_scrape',


### PR DESCRIPTION
#### What's this PR do?
* Creates Rogue consumer for events to get loaded into Postgres based data warehouse.
* Simplifies `pydash.get` check logic from `if not` to `if` as discussed in another PR with @DFurnes. Specifically see https://github.com/DoSomething/quasar/blob/rogue-pg-consumer/quasar/quasar_queue.py#L263-L265 vs https://github.com/DoSomething/quasar/blob/rogue-pg-consumer/quasar/quasar_queue.py#L430-L432.
* Bumps version to `0.4.0`

#### Where should the reviewer start?
https://github.com/DoSomething/quasar/blob/rogue-pg-consumer/quasar/quasar_queue.py#L283

#### How should this be manually tested?
I was able to successfully test consuming Blink staging `quasar.rogue-pg` messages to my local DB successfully, which had ~11000 events, including a signup delete and uploaded post_details.

#### Any background context you want to provide?
We're migrating from MySQL to Postgres, and this should handle the Rogue ingestion point.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/155919704

