### PR TITLE
Adding varchar cast to compare int substituted value.

### DIFF
--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -313,7 +313,7 @@ class RoguePostgresQueue(QuasarQueue):
         # Get created_at date of signup.
         created_at = self.db.query_str(''.join(("SELECT created_at "
                                                 "FROM rogue.signups WHERE "
-                                                "id = %s")),
+                                                "id = %s::varchar")),
                                        (signup_id,))
         self.db.query_str(''.join(("INSERT INTO rogue.signups "
                                    "(id, created_at, updated_at, "
@@ -355,7 +355,7 @@ class RoguePostgresQueue(QuasarQueue):
         # Get created_at timestamp of post.
         created_at = self.db.query_str(''.join(("SELECT created_at "
                                                 "FROM rogue.posts WHERE "
-                                                "id = %s")),
+                                                "id = %s::varchar")),
                                        (post_id,))
         # Set post status to 'deleted'.
         self.db.query_str(''.join(("INSERT INTO rogue.posts "


### PR DESCRIPTION
#### What's this PR do?
Postgres requires a typecast to `varchar` to compare an int against a varchar value. This PR adds syntax for deleted signups and posts that were giving errors. 
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/int-pg-typecast?expand=1#diff-68da9c0535d3768969007f65eaf1ffd9
#### How should this be manually tested?
Manually tested against Prod data.

