### PR TITLE
Cio pg consumer

### DIFF
--- a/quasar/cio_consumer_pg.py
+++ b/quasar/cio_consumer_pg.py
@@ -1,4 +1,3 @@
-from .config import config
 from .quasar_queue import CioPostgresQueue
 
 

--- a/quasar/cio_consumer_pg.py
+++ b/quasar/cio_consumer_pg.py
@@ -1,0 +1,9 @@
+from .config import config
+from .quasar_queue import CioPostgresQueue
+
+
+queue = CioPostgresQueue()
+
+
+def main():
+    queue.start_consume()

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,14 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="0.5.0",
+    version="0.6.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={
         'console_scripts': [
             'campaign_info_table_refresh = quasar.phoenix_to_campaign_info_table:main',
             'cio_import = quasar.cio_queue_process:main',
+            'cio_import_pg = quasar.cio_consumer_pg:main',
             'etl_monitoring = quasar.etl_monitoring:run_monitoring',
             'get_competitions = quasar.gladiator_import:get_competitions',
             'legacy_cio_backfill = quasar.cio_legacy_backfill:legacy_cio_backfill',


### PR DESCRIPTION
#### What's this PR do?
- Expands c.io pg consumer to be able to parse various c.io based events and write to a Postgres database instead of MySQL.
- Adds entry point/command to run the consumer.
- Bumps Quasar version to `0.6.0`

#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/cio-pg-consumer?expand=1#diff-68da9c0535d3768969007f65eaf1ffd9

#### How should this be manually tested?
This one we're going to have to test manually in our Prod environment, since staging for some reason doesn't get enough c.io traffic. Still coordinating with Rafa on it.

#### Any background context you want to provide?
Next data pipeline to migrate to Postgres. 

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/155919553