### PR TITLE
Separated out customer unsub/sub events since subs have no template_id.

### DIFF
--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -94,8 +94,25 @@ class CioPostgresQueue(QuasarQueue):
         print(''.join(("Logged data from "
                        "C.IO event id {}.")).format(data['event_id']))
 
-    # Save customer sub/unsub data and dates.
-    def _add_customer_event(self, data):
+    # Save customer sub data and dates.
+    def _add_sub_event(self, data):
+        self.db.query_str(''.join(("INSERT INTO cio.customer_event "
+                                   "(email_id, customer_id, email_address, "
+                                   "event_id, to_timestamp(timestamp), "
+                                   "event_type VALUES (%s,%s,%s,%s,%s,%s,%s) "
+                                   "ON CONFLICT (email_id, customer_id, "
+                                   "timestamp, event_type) "
+                                   "DO NOTHING")),
+                          (data['data']['email_id'],
+                           data['data']['customer_id'],
+                           data['data']['email_address'],
+                           data['event_id'], data['timestamp'],
+                           data['event_type']))
+        print(''.join(("Added customer event from "
+                       "C.IO event id {}.")).format(data['event_id']))
+
+    # Save customer unsub data and dates.
+    def _add_unsub_event(self, data):
         self.db.query_str(''.join(("INSERT INTO cio.customer_event "
                                    "(email_id, customer_id, email_address, "
                                    "template_id, event_id, "
@@ -159,26 +176,22 @@ class CioPostgresQueue(QuasarQueue):
     def process_message(self, message_data):
         data = message_data['data']
         event_type = pydash.get(data, 'event_type')
-        # Set for checking customer event types.
-        customer_event = {
-            'customer_subscribed',
-            'customer_unsubscribed'
-        }
         # Set for checking email event types.
         email_event = {
             'email_converted',
             'email_opened',
             'email_unsubscribed'
         }
-        email_click_event = {'email_clicked'}
         # Always capture atomic c.io event in raw format.
         self._log_event(data)
-        if event_type in customer_event:
-            self._add_customer_event(data)
+        if event_type == 'customer_subscribed':
+            self._add_sub_event(data)
+        elif event_type == 'customer_unsubscribed':
+            self._add_unsub_event(data)
+        elif event_type == 'email_clicked':
+            self._add_email_click_event(data)
         elif event_type in email_event:
             self._add_email_event(data)
-        elif event_type in email_click_event:
-            self._add_email_click_event(data)
         else:
             print("Something went wrong with C.IO consumer!")
             sys.exit(1)


### PR DESCRIPTION
#### What's this PR do?
Customer subs don't contain template_id's. Added additional method for processing events separately, as well as check for those specific type of events. 
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/cio-consumer-fix-3?expand=1#diff-68da9c0535d3768969007f65eaf1ffd9L97
#### How should this be manually tested?
Will test on C.IO prod consumer.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/155919553

