### PR TITLE
We get link_id, not link from C.IO. Updated code to reflect this.

### DIFF
--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -155,7 +155,7 @@ class CioPostgresQueue(QuasarQueue):
     def _add_email_click_event(self, data):
         self.db.query_str(''.join(("INSERT INTO cio.email_event "
                                    "(email_id, customer_id, email_address, "
-                                   "template_id, subject, href, link, "
+                                   "template_id, subject, href, link_id, "
                                    "event_id, timestamp, "
                                    "event_type) VALUES "
                                    "(%s,%s,%s,%s,%s,%s,%s,%s,"
@@ -169,7 +169,7 @@ class CioPostgresQueue(QuasarQueue):
                            data['data']['template_id'],
                            data['data']['subject'],
                            data['data']['href'],
-                           data['data']['link'],
+                           data['data']['link_id'],
                            data['event_id'], data['timestamp'],
                            data['event_type']))
         print(''.join(("Added email event from "


### PR DESCRIPTION
#### What's this PR do?
* Changed the field processing from `link` to `link_id`, which is what we actually get from c.io.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/cio-consumer-fix-7?expand=1#diff-68da9c0535d3768969007f65eaf1ffd9L158
#### How should this be manually tested?
* Like all other PR's in this series, de-bugging in Prod is the fun and only way to go. All hail no tests and pushing live!
#### Any background context you want to provide?
* Final fix for c.io Postgres consumer (like, 96.837% sure).
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/155919553

