### PR TITLE
Adding user role to scope to Northstar scraper.

### DIFF
--- a/quasar/northstarscraper.py
+++ b/quasar/northstarscraper.py
@@ -16,10 +16,11 @@ class NorthstarScraper(Scraper):
     def fetch_auth_headers(self):
         oauth = OAuth2Session(client=BackendApplicationClient(
             client_id=config.ns_client_id))
+        scopes = ['admin', 'user']
         new_token = oauth.fetch_token(self.url + '/v2/auth/token',
                                       client_id=config.ns_client_id,
                                       client_secret=config.ns_client_secret,
-                                      scope='admin')
+                                      scope=scopes)
         return {'Authorization': 'Bearer ' + str(new_token['access_token'])}
 
     def authenticated(func):


### PR DESCRIPTION
#### What's this PR do?
Fix for adding `user` scope to Northstar scraper. This scope is required for the Northstar /users/ API to be properly accessed.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/northstar-fix?expand=1#diff-d7b61674a54619ac6e6d51fc18491489R19
#### How should this be manually tested?
Tested locally against both staging and prod Northstar URI's.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/156374893

