### PR TITLE
Upping ToroDB Sync Time to 45 mins from 30 as Puck DB has grown.

### DIFF
--- a/quasar/misc/puck-to-quasar-pg.sh
+++ b/quasar/misc/puck-to-quasar-pg.sh
@@ -17,9 +17,9 @@ mongorestore --drop /var/tmp/puck-mongo-dump
 # ToroDB Stampede to Quasar PostgreSQL DB
 sudo torodb-stampede &
 
-# Sleep for 30 mins to allow for full sync
+# Sleep for 45 mins to allow for full sync
 echo "Waiting for ToroDB sync to finish."
-for i in {1..1800}
+for i in {1..2700}
 do
   echo "Been asleep for $i seconds."
   sleep 1


### PR DESCRIPTION
#### What's this PR do?
Increase ToroDB sync time to 45 minutes for larger Puck DB.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/up-torodb-sync-time?expand=1#diff-3db5d981bb88a2a2af5be5c4a080c08aL20
#### How should this be manually tested?
Will re-run job to test.
#### Any background context you want to provide?
Puck DB has grown to almost 8 GB from initial 1. This is another bump up.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/156434174

