### PR TITLE
Generate Postgres campaign_info as materialized view.

### DIFF
--- a/quasar/ashes_to_campaign_info.py
+++ b/quasar/ashes_to_campaign_info.py
@@ -4,7 +4,7 @@ import time
 import sys
 
 
-def main():
+def create():
     start_time = time.time()
     """Keep track of start time of script."""
 
@@ -84,6 +84,22 @@ def main():
     end_time = time.time()  # Record when script stopped running.
     duration = end_time - start_time  # Total duration in seconds.
     print('duration: ', duration)
+
+def main():
+    start_time = time.time()
+    """Keep track of start time of script."""
+
+    db = Database()
+
+    db.query('REFRESH MATERIALIZED VIEW campaign_info')
+    db.disconnect()
+
+    end_time = time.time()  # Record when script stopped running.
+    duration = end_time - start_time  # Total duration in seconds.
+    print('duration: ', duration)
+
+if __name__ == "__create__":
+    create()
 
 if __name__ == "__main__":
     main()

--- a/quasar/ashes_to_campaign_info.py
+++ b/quasar/ashes_to_campaign_info.py
@@ -1,0 +1,89 @@
+from .database_pg import Database
+from .config import config
+import time
+import sys
+
+
+def main():
+    start_time = time.time()
+    """Keep track of start time of script."""
+
+    db = Database()
+
+    db.query('DROP MATERIALIZED VIEW IF EXISTS campaign_info')
+    # Query to update Quasar campaign_info table from Ashes DB.
+    db.query(''.join("CREATE MATERIALIZED VIEW IF NOT EXISTS "
+                     "campaign_info AS ( "
+                      "SELECT "
+                      "c.field_campaigns_target_id as campaign_node_id,"
+                      "n2.title as campaign_node_id_title,"
+                      "c.entity_id as campaign_run_id,"
+                      "n1.title as campaign_run_id_title,"
+                      "fdfct.field_campaign_type_value as campaign_type,"
+                      "c.language as campaign_language,"
+                      "fdfrd.field_run_date_value as campaign_run_start_date,"
+                      "fdfrd.field_run_date_value2 as campaign_run_end_date,"
+                      "to_timestamp(n1.created) as campaign_created_date,"
+                      "fdfrn.field_reportback_noun_value as campaign_noun,"
+                      "fdfrv.field_reportback_verb_value as campaign_verb,"
+                      "array_to_string(array_agg(distinct ttd2.name), ', ') "
+                      "as campaign_cause_type,"
+                      "array_to_string(array_agg("
+                      "distinct fdfcta.field_call_to_action_value), ', ') "
+                      "as campaign_cta,"
+                      "array_to_string(array_agg(distinct ttd1.name), ', ') "
+                      "as campaign_action_type "
+                      "FROM dosomething.field_data_field_campaigns c "
+                      "LEFT JOIN "
+                      "dosomething.node n1 "
+                      "ON n1.nid = c.entity_id "
+                      "LEFT JOIN "
+                      "dosomething.node n2 "
+                      "ON n2.nid = c.field_campaigns_target_id "
+                      "LEFT JOIN "
+                      "dosomething.field_data_field_campaign_type fdfct "
+                      "ON c.field_campaigns_target_id = fdfct.entity_id "
+                      "LEFT JOIN "
+                      "dosomething.field_data_field_run_date fdfrd " 
+                      "ON c.entity_id = fdfrd.entity_id and c.language = "
+                      "fdfrd.language "
+                      "LEFT JOIN "
+                      "dosomething.field_data_field_call_to_action fdfcta "
+                      "ON c.field_campaigns_target_id = fdfcta.entity_id and "
+                      "c.language = fdfcta.language "
+                      "LEFT JOIN "
+                      "dosomething.field_data_field_reportback_noun fdfrn "
+                      "ON c.field_campaigns_target_id = fdfrn.entity_id and "
+                      "c.language = fdfrn.language "
+                      "LEFT JOIN "
+                      "dosomething.field_data_field_reportback_verb fdfrv "
+                      "ON c.field_campaigns_target_id = fdfrv.entity_id "
+                      "and c.language = fdfrv.language "
+                      "LEFT JOIN "
+                      "dosomething.field_data_field_action_type fdfat "
+                      "ON fdfat.entity_id = c.field_campaigns_target_id "
+                      "LEFT JOIN "
+                      "dosomething.taxonomy_term_data ttd1 "
+                      "ON fdfat.field_action_type_tid = ttd1.tid "
+                      "LEFT JOIN "
+                      "dosomething.field_data_field_cause fdfc "
+                      "ON fdfc.entity_id = c.field_campaigns_target_id "
+                      "LEFT JOIN "
+                      "dosomething.taxonomy_term_data ttd2 "
+                      "ON fdfc.field_cause_tid = ttd2.tid "
+                      "WHERE c.bundle = 'campaign_run' "
+                      "GROUP BY 1,2,3,4,5,6,7,8,9,10,11 "
+                      "ORDER BY c.field_campaigns_target_id, "
+                      "fdfrd.field_run_date_value)"))
+    db.query('GRANT SELECT ON campaign_info TO looker')
+    db.query('GRANT SELECT ON campaign_info TO jjensen')
+    db.query('GRANT SELECT ON campaign_info TO jli')
+    db.query('GRANT SELECT ON campaign_info TO shasan')
+    db.disconnect()
+
+    end_time = time.time()  # Record when script stopped running.
+    duration = end_time - start_time  # Total duration in seconds.
+    print('duration: ', duration)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     entry_points={
         'console_scripts': [
             'campaign_info_table_refresh = quasar.phoenix_to_campaign_info_table:main',
+            'campaign_info_recreate_pg = quasar.ashes_to_campaign_info:create',
             'campaign_info_refresh_pg = quasar.ashes_to_campaign_info:main',
             'cio_import = quasar.cio_queue_process:main',
             'cio_import_pg = quasar.cio_consumer_pg:main',

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,13 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="0.6.0",
+    version="0.6.1",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={
         'console_scripts': [
             'campaign_info_table_refresh = quasar.phoenix_to_campaign_info_table:main',
+            'campaign_info_refresh_pg = quasar.ashes_to_campaign_info:main',
             'cio_import = quasar.cio_queue_process:main',
             'cio_import_pg = quasar.cio_consumer_pg:main',
             'etl_monitoring = quasar.etl_monitoring:run_monitoring',


### PR DESCRIPTION
#### What's this PR do?
* Generates `campaign_info` table from Ashes as a materialized view in Postgres.
* Refreshes `campaign_info` materialized view.
* Bumps version of Quasar to `0.6.1`.

#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/campaign_info_pg?expand=1#diff-eb8f52d8385e6b5e518520737ff2cd6e
#### How should this be manually tested?
Tested against staging from localhost, and confirmed by @sohaibhasan.
#### Any background context you want to provide?
Having a materialized view allows us to generate this table on the fly without it needing to be a PDT, and to get refreshes regularly.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/155919125

