### PR TITLE
Updating dump command to use Atlas cluster vs. mLab.

### DIFF
--- a/quasar/misc/puck-to-quasar-pg.sh
+++ b/quasar/misc/puck-to-quasar-pg.sh
@@ -7,7 +7,7 @@ echo "Old Puck mongo backup deleted."
 
 # Source Env Variables and Dump Puck DB
 source ~/.mongorc.js
-mongodump -h $PUCK_DB:$PUCK_PORT -d $PUCK_AUTH_DB -u $PUCK_USER -p $PUCK_PASS -o /var/tmp/puck-mongo-dump
+mongodump -h "$PUCK_DB" -d $PUCK_DUMP_DB -u $PUCK_USER -p $PUCK_PASS --ssl --authenticationDatabase $PUCK_AUTH_DB -o /var/tmp/puck-mongo-dump
 echo "Puck mongo backup complete."
 
 # Restore to internal mongo cluster.


### PR DESCRIPTION
#### What's this PR do?
Updates Puck ETL import to use new Mongo Atlas backend cluster as source instead of mLab db.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/puck-atlas-fix?expand=1#diff-3db5d981bb88a2a2af5be5c4a080c08a
#### How should this be manually tested?
Manually tested dump command on Quasar node.

