### PR TITLE
Removing post details for Rogue MySQL consumer.

### DIFF
--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -297,66 +297,6 @@ class RogueQueue(QuasarQueue):
                            post_data['type']))
         print("Post {} ETL'd.".format(post_data['id']))
 
-    def _add_post_details(self, post_id, post_details):
-        # TODO: Remove type check if Rogue sends this as JSON/dict.
-        if type(post_details) is str:
-            details = json.loads(post_details)
-        else:
-            details = post_details
-        if pydash.get(details, 'source_details'):
-            self.db.query_str(''.join(("REPLACE INTO ",
-                                       self.campaign_activity_details,
-                                       " SET post_id = %s, hostname = %s, "
-                                       "referral_code = %s, "
-                                       "partner_comms_opt_in = %s, "
-                                       "created_at = %s, updated_at = %s, "
-                                       "source_details = %s, "
-                                       "voter_registration_status = %s, "
-                                       "voter_registration_source = %s, "
-                                       "voter_registration_method = %s, "
-                                       "voting_method_preference = %s, "
-                                       "email_subscribed = %s, "
-                                       "sms_subscribed = %s")),
-                              (post_id,
-                               details['hostname'],
-                               details['referral-code'],
-                               details['partner-comms-opt-in'],
-                               details['created-at'],
-                               details['updated-at'],
-                               details['source_details'],
-                               details['voter-registration-status'],
-                               details['voter-registration-source'],
-                               details['voter-registration-method'],
-                               details['voting-method-preference'],
-                               details['email subscribed'],
-                               details['sms subscribed']))
-        else:
-            self.db.query_str(''.join(("REPLACE INTO ",
-                                       self.campaign_activity_details,
-                                       " SET post_id = %s, hostname = %s, "
-                                       "referral_code = %s, "
-                                       "partner_comms_opt_in = %s, "
-                                       "created_at = %s, updated_at = %s, "
-                                       "voter_registration_status = %s, "
-                                       "voter_registration_source = %s, "
-                                       "voter_registration_method = %s, "
-                                       "voting_method_preference = %s, "
-                                       "email_subscribed = %s, "
-                                       "sms_subscribed = %s")),
-                              (post_id,
-                               details['hostname'],
-                               details['referral-code'],
-                               details['partner-comms-opt-in'],
-                               details['created-at'],
-                               details['updated-at'],
-                               details['voter-registration-status'],
-                               details['voter-registration-source'],
-                               details['voter-registration-method'],
-                               details['voting-method-preference'],
-                               details['email subscribed'],
-                               details['sms subscribed']))
-        print("Details for post {} ETL'd.".format(post_id))
-
     def _delete_post(self, post_id, deleted_at):
         # Set post status to 'deleted'.
         self.db.query_str(''.join(("UPDATE ",
@@ -393,11 +333,6 @@ class RogueQueue(QuasarQueue):
         elif data['meta']['type'] == 'post':
             if not pydash.get(data, 'deleted_at'):
                 self._add_post(data)
-                if (pydash.get(data, 'details') is None or
-                        pydash.get(data, 'details') == ''):
-                    pass
-                else:
-                    self._add_post_details(data['id'], data['details'])
             else:
                 self._delete_post(data['id'], data['deleted_at'])
         else:


### PR DESCRIPTION
#### What's this PR do?
- Removes Rogue posts details processing from Rogue MySQL consumer, since it's causing a backlog of Rogue events that are non-Turbovote formatted, and we'll be capturing them in the updated Rogue Postgres consumer.

#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/rogue-mysql-remove-post-details?expand=1#diff-68da9c0535d3768969007f65eaf1ffd9
#### How should this be manually tested?
Will test it out LIVE!


#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/157006917

