### PR TITLE
Phoenix derived campaign bugfix

### DIFF
--- a/quasar/misc/puck_etl.sql
+++ b/quasar/misc/puck_etl.sql
@@ -9,7 +9,10 @@ CREATE TEMPORARY TABLE path_campaign_lookup AS
 		camps.campaign_name
 	FROM 
 		(SELECT DISTINCT 
-			COALESCE(dat.legacycampaignid_s,dat.campaignid_s)::NUMERIC AS campaign_id,
+			COALESCE(
+				regexp_replace(dat.legacycampaignid_s, '[[:alpha:]]','','g'),
+				regexp_replace(dat.campaignid_s, '[[:alpha:]]','','g')
+				)::NUMERIC AS campaign_id,
 			(regexp_split_to_array(page.path_s, E'\/'))[4] AS campaign_name
 			FROM heroku_wzsf6b3z.events_meta meta
 			LEFT JOIN heroku_wzsf6b3z.events_data dat ON dat.did = meta.did

--- a/quasar/misc/puck_etl.sql
+++ b/quasar/misc/puck_etl.sql
@@ -9,7 +9,7 @@ CREATE TEMPORARY TABLE path_campaign_lookup AS
 		camps.campaign_name
 	FROM 
 		(SELECT DISTINCT 
-			dat.campaignid_s::NUMERIC AS campaign_id,
+			COALESCE(dat.legacycampaignid_s,dat.campaignid_s)::NUMERIC AS campaign_id,
 			(regexp_split_to_array(page.path_s, E'\/'))[4] AS campaign_name
 			FROM heroku_wzsf6b3z.events_meta meta
 			LEFT JOIN heroku_wzsf6b3z.events_data dat ON dat.did = meta.did

--- a/quasar/misc/puck_etl.sql
+++ b/quasar/misc/puck_etl.sql
@@ -10,8 +10,8 @@ CREATE TEMPORARY TABLE path_campaign_lookup AS
 	FROM 
 		(SELECT DISTINCT 
 			COALESCE(
-				regexp_replace(dat.legacycampaignid_s, '[[:alpha:]]','','g'),
-				regexp_replace(dat.campaignid_s, '[[:alpha:]]','','g')
+				regexp_replace(dat.legacycampaignid_s, '[^0-9.]','','g'),
+				regexp_replace(dat.campaignid_s, '[^0-9.]','','g')
 				)::NUMERIC AS campaign_id,
 			(regexp_split_to_array(page.path_s, E'\/'))[4] AS campaign_name
 			FROM heroku_wzsf6b3z.events_meta meta


### PR DESCRIPTION
#### What's this PR do?
Resolves a bug in the puck_etl.sql script to account for campaign ids now appearing in a new field called legacycampaignid_s

#### Where should the reviewer start?
puck_etl.sql

#### How should this be manually tested?
1) Does the puck_etl.sql file run without error via torod?
2) Do all of our looks build correctly?

#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/157008487

#### Screenshots (if appropriate)
#### Questions:
