### PR TITLE
Tuning back down ToroDB sync since runs faster with better hardware.

### DIFF
--- a/quasar/misc/puck-to-quasar-pg.sh
+++ b/quasar/misc/puck-to-quasar-pg.sh
@@ -17,9 +17,9 @@ mongorestore --drop /var/tmp/puck-mongo-dump
 # ToroDB Stampede to Quasar PostgreSQL DB
 sudo torodb-stampede &
 
-# Sleep for 45 mins to allow for full sync
+# Sleep for 15 mins to allow for full sync
 echo "Waiting for ToroDB sync to finish."
-for i in {1..2700}
+for i in {1..900}
 do
   echo "Been asleep for $i seconds."
   sleep 1


### PR DESCRIPTION
#### What's this PR do?
Makes Puck ETL script ToroDB step take 15 minutes instead of 45, since on multiple manual runs, it moves faster since we've upped the hardware running behind it.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/puck-etl-faster?expand=1#diff-3db5d981bb88a2a2af5be5c4a080c08a
#### How should this be manually tested?
Testing LIVE!
