### PR TITLE
Removing campaign_run_id from rogue.posts table.

### DIFF
--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -383,18 +383,17 @@ class RoguePostgresQueue(QuasarQueue):
     def _add_post(self, post_data):
         self.db.query_str(''.join(("INSERT INTO rogue.posts "
                                    "(id, signup_id, campaign_id, "
-                                   "campaign_run_id, northstar_id, "
+                                   "northstar_id, "
                                    "type, action, quantity, url, caption, "
                                    "status, source, signup_source, "
                                    "remote_addr, created_at, "
                                    "updated_at) VALUES "
-                                   "(%s,%s,%s,%s,%s,%s,%s,%s,%s,"
+                                   "(%s,%s,%s,%s,%s,%s,%s,%s,"
                                    "%s,%s,%s,%s,%s,%s,%s) ON CONFLICT "
                                    "DO NOTHING")),
                           (post_data['id'],
                            post_data['signup_id'],
                            post_data['campaign_id'],
-                           post_data['campaign_run_id'],
                            post_data['northstar_id'],
                            post_data['type'],
                            post_data['action'],


### PR DESCRIPTION
#### What's this PR do?
- Removes campaign_run_id from rogue.posts table to better mirror Rogue prod.
- Queries that need this to persist in derived tables.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/remove-run-id-post?expand=1#diff-68da9c0535d3768969007f65eaf1ffd9
#### How should this be manually tested?
Doing it live.
