### PR TITLE
Update path_campaign_lookup to be mat view instead of temp table

### DIFF
--- a/quasar/misc/create_puck_etl.sql
+++ b/quasar/misc/create_puck_etl.sql
@@ -1,8 +1,9 @@
+DROP MATERIALIZED VIEW IF EXISTS public.path_campaign_lookup;
 DROP MATERIALIZED VIEW IF EXISTS public.phoenix_next_events; 
 DROP MATERIALIZED VIEW IF EXISTS public.phoenix_next_sessions; 
-DROP MATERIALIZED VIEW IF EXISTS public.device_northstar_crosswalk; 
+DROP MATERIALIZED VIEW IF EXISTS public.device_northstar_crosswalk;
 
-CREATE TEMPORARY TABLE path_campaign_lookup AS 
+CREATE MATERIALIZED VIEW public.path_campaign_lookup AS 
 	(
 	SELECT 
 		max(camps.campaign_id) AS campaign_id,

--- a/quasar/misc/puck_etl.sql
+++ b/quasar/misc/puck_etl.sql
@@ -1,3 +1,4 @@
+REFRESH MATERIALIZED VIEW public.path_campaign_lookup;
 REFRESH MATERIALIZED VIEW public.phoenix_next_events;
 REFRESH MATERIALIZED VIEW public.phoenix_next_sessions;
 REFRESH MATERIALIZED VIEW public.device_northstar_crosswalk;


### PR DESCRIPTION
#### What's this PR do?
- Updates Puck tables to create `path_campaign_lookup` to be mat view instead of temp table.
- Updates puck_etl to refresh `path_campaign_lookup` before regen'ing rest of tables.
#### Where should the reviewer start?
- https://github.com/DoSomething/quasar/compare/path-campaign?expand=1#diff-964a67451596ac2549067043ef570bcb
#### How should this be manually tested?
- Manually ran from DBeaver, and succeeds.
