### PR TITLE
Removing extra semi-colon that causes error.

### DIFF
--- a/quasar/misc/create_puck_etl.sql
+++ b/quasar/misc/create_puck_etl.sql
@@ -105,7 +105,7 @@ CREATE MATERIALIZED VIEW public.phoenix_next_sessions AS
 		GROUP BY page_temp.sessionid_s) use ON page.sessionid_s = use.sessionid_s
 	LEFT JOIN heroku_wzsf6b3z.events_page_referrer refer ON refer.did = page.did
 	LEFT JOIN heroku_wzsf6b3z.events_page_referrer_query ref_q ON ref_q.did = page.did
-	GROUP BY page.sessionid_s;)
+	GROUP BY page.sessionid_s)
 ;
 
 CREATE MATERIALIZED VIEW public.device_northstar_crosswalk AS 


### PR DESCRIPTION
#### What's this PR do?
Removes extraneous `;` from SQL ETL creation statement, since the query causes errors.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/create-puck-etl-fix?expand=1#diff-964a67451596ac2549067043ef570bcb
#### How should this be manually tested?
Already tested query in Prod.

