### PR TITLE
Hotfix to handle lack of template_id in customer_unsubscribed events.

### DIFF
--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -144,7 +144,7 @@ class CioPostgresQueue(QuasarQueue):
                                data['data']['customer_id'],
                                data['data']['email_address'],
                                data['event_id'], data['timestamp'],
-                               data['event_type']))            
+                               data['event_type']))
         print(''.join(("Added customer event from "
                        "C.IO event id {}.")).format(data['event_id']))
 

--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -114,21 +114,37 @@ class CioPostgresQueue(QuasarQueue):
 
     # Save customer unsub data and dates.
     def _add_unsub_event(self, data):
-        self.db.query_str(''.join(("INSERT INTO cio.customer_event "
-                                   "(email_id, customer_id, email_address, "
-                                   "template_id, event_id, "
-                                   "timestamp, event_type) "
-                                   "VALUES (%s,%s,%s,%s,%s,"
-                                   "to_timestamp(%s),%s) "
-                                   "ON CONFLICT (email_id, customer_id, "
-                                   "timestamp, event_type) "
-                                   "DO NOTHING")),
-                          (data['data']['email_id'],
-                           data['data']['customer_id'],
-                           data['data']['email_address'],
-                           data['data']['template_id'],
-                           data['event_id'], data['timestamp'],
-                           data['event_type']))
+        if pydash.get(data, 'template_id'):
+            self.db.query_str(''.join(("INSERT INTO cio.customer_event "
+                                       "(email_id, customer_id,"
+                                       "email_address, template_id, event_id,"
+                                       "timestamp, event_type) "
+                                       "VALUES (%s,%s,%s,%s,%s,"
+                                       "to_timestamp(%s),%s) "
+                                       "ON CONFLICT (email_id, customer_id, "
+                                       "timestamp, event_type) "
+                                       "DO NOTHING")),
+                              (data['data']['email_id'],
+                               data['data']['customer_id'],
+                               data['data']['email_address'],
+                               data['data']['template_id'],
+                               data['event_id'], data['timestamp'],
+                               data['event_type']))
+        else:
+            self.db.query_str(''.join(("INSERT INTO cio.customer_event "
+                                       "(email_id, customer_id,"
+                                       "email_address, event_id, "
+                                       "timestamp, event_type) "
+                                       "VALUES (%s,%s,%s,%s,"
+                                       "to_timestamp(%s),%s) "
+                                       "ON CONFLICT (email_id, customer_id, "
+                                       "timestamp, event_type) "
+                                       "DO NOTHING")),
+                              (data['data']['email_id'],
+                               data['data']['customer_id'],
+                               data['data']['email_address'],
+                               data['event_id'], data['timestamp'],
+                               data['event_type']))            
         print(''.join(("Added customer event from "
                        "C.IO event id {}.")).format(data['event_id']))
 


### PR DESCRIPTION
#### What's this PR do?
Hotfix to handle unsubscribe events with no `template_id`.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/unsub-no-template?expand=1#diff-68da9c0535d3768969007f65eaf1ffd9
#### How should this be manually tested?
Tested in Staging.
#### Any background context you want to provide?
Users can potentially unsubscribe with no `template_id` if they don't visit actual C.IO landing page.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/157443780