### PR TITLE
Refresh users and campaign_activity derived tables.

### DIFF
--- a/quasar/refresh_campaign_activity.py
+++ b/quasar/refresh_campaign_activity.py
@@ -1,0 +1,19 @@
+from .database_pg import Database
+import time
+
+
+def main():
+    db = Database()
+    start_time = time.time()
+    """Keep track of start time of script."""
+
+    db.query("REFRESH MATERIALIZED VIEW public.users")
+    db.query("REFRESH MATERIALIZED VIEW public.cio_latest_status")
+
+    end_time = time.time()  # Record when script stopped running.
+    duration = end_time - start_time  # Total duration in seconds.
+    print('duration: ', duration)
+
+
+if __name__ == "__main__":
+    main()

--- a/quasar/refresh_derived_users.py
+++ b/quasar/refresh_derived_users.py
@@ -6,7 +6,7 @@ def main():
     db = Database()
     start_time = time.time()
     """Keep track of start time of script."""
-    
+        
     db.query("REFRESH MATERIALIZED VIEW public.signups")
     db.query("REFRESH MATERIALIZED VIEW public.posts")
     db.query("REFRESH MATERIALIZED VIEW public.reported_back")

--- a/quasar/refresh_derived_users.py
+++ b/quasar/refresh_derived_users.py
@@ -1,0 +1,21 @@
+from .database_pg import Database
+import time
+
+
+def main():
+    db = Database()
+    start_time = time.time()
+    """Keep track of start time of script."""
+    
+    db.query("REFRESH MATERIALIZED VIEW public.signups")
+    db.query("REFRESH MATERIALIZED VIEW public.posts")
+    db.query("REFRESH MATERIALIZED VIEW public.reported_back")
+    db.query("REFRESH MATERIALIZED VIEW public.campaign_activity")
+
+    end_time = time.time()  # Record when script stopped running.
+    duration = end_time - start_time  # Total duration in seconds.
+    print('duration: ', duration)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="0.7.2",
+    version="0.8.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={
@@ -13,6 +13,7 @@ setup(
             'campaign_info_table_refresh = quasar.phoenix_to_campaign_info_table:main',
             'campaign_info_recreate_pg = quasar.ashes_to_campaign_info:create',
             'campaign_info_refresh_pg = quasar.ashes_to_campaign_info:main',
+            'campaign_activity_refresh = quasar.refresh_campaign_activity:main',
             'cio_import = quasar.cio_queue_process:main',
             'cio_import_pg = quasar.cio_consumer_pg:main',
             'etl_monitoring = quasar.etl_monitoring:run_monitoring',
@@ -30,7 +31,8 @@ setup(
             'rogue_consume_pg = quasar.rogue_consumer_pg:main',
             'rogue_ghost_killer = quasar.ghost_killer:main',
             'runscope_cleanup = quasar.cio_runscope_queue_cleanup:main',
-            'reportbacks_asterisk = quasar.reportback_asterisk:run_load_reportbacks'
+            'reportbacks_asterisk = quasar.reportback_asterisk:run_load_reportbacks',
+            'users_refresh = quasar.refresh_derived_users:main'
         ],
     },
     author="",


### PR DESCRIPTION
#### What's this PR do?
* Adds refresh mat view statement for derived `users` table and dependencies.
* Adds refresh mat view statement for derived `campaign_activity` table and dependencies.
* Bumps Quasar version up to `0.8.0`.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/user-ca-refresh?expand=1#diff-a84354344be1123fdce649dcf03ee141
#### How should this be manually tested?
Tables already created, will test on Jenkins once merged.
#### Any background context you want to provide?

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/156631235
