### PR TITLE
Bertly refresh

### DIFF
--- a/quasar/aws_dms.py
+++ b/quasar/aws_dms.py
@@ -24,7 +24,7 @@ def check_refresh_status(aws_arn):
                                           'ReplicationTasks.0.StopReason')
     refresh_status['progress'] = pydash.get(task_progess,
                                             'ReplicationTasks.0.ReplicationTaskStats.FullLoadProgressPercent')
-    
+
     if (refresh_status['status'] == 'stopped' and
             refresh_status['reason'] == 'Stop Reason FULL_LOAD_ONLY_FINISHED' and
             refresh_status['progress'] == 100):

--- a/quasar/aws_dms.py
+++ b/quasar/aws_dms.py
@@ -25,8 +25,8 @@ def check_refresh_status(aws_arn):
     refresh_status['progress'] = pydash.get(task_progess,
                                             'ReplicationTasks.0.ReplicationTaskStats.FullLoadProgressPercent')
     if (refresh_status['status'] == 'stopped' and
-            refresh_status['reason'] == 'Stop Reason FULL_LOAD_ONLY_FINISHED'
-            and refresh_status['progress'] == 100):
+        refresh_status['reason'] == 'Stop Reason FULL_LOAD_ONLY_FINISHED' and
+        refresh_status['progress'] == 100):
         return True
     else:
         return False

--- a/quasar/aws_dms.py
+++ b/quasar/aws_dms.py
@@ -1,0 +1,41 @@
+import boto3
+import pydash
+
+dms = boto3.client('dms')
+
+
+def start_dms_refresh(aws_arn):
+    # Refresh DMS with full reload by passing in arn, including 'arn:' part.
+    dms.start_replication_task(ReplicationTaskArn=aws_arn,
+                               StartReplicationTaskType='reload-target')
+
+
+def check_refresh_status(aws_arn):
+    # Report back metrics for DMS progress.
+    task_progess = dms.describe_replication_tasks(Filters=[
+        {'Name': 'replication-task-arn',
+         'Values': [aws_arn]}])
+    refresh_status = {}
+    refresh_status['status'] = pydash.get(task_progess,
+                                          'ReplicationTasks.0.Status')
+    refresh_status['reason'] = pydash.get(task_progess,
+                                          'ReplicationTasks.0.StopReason')
+    refresh_status['progress'] = pydash.get(task_progess,
+                                            'ReplicationTasks.0.ReplicationTaskStats.FullLoadProgressPercent')
+    if (status['status'] == 'stopped' and
+        status['reason'] == 'Stop Reason FULL_LOAD_ONLY_FINISHED' and
+        status['progress'] == 100):
+        return True
+    else:
+        return False
+
+def refresh_finished(aws_arn):
+    # Return true only when refresh is finished.
+    status = check_refresh_status()
+    while not check_refresh_status(aws_arn):
+        # SLeep between checks for 60 seconds, then try again.
+        print("DMS refresh still not done, checking in 60.")
+        time.sleep(60)
+        status = check_refresh_status()
+    print("DMS finished!")
+    return None

--- a/quasar/aws_dms.py
+++ b/quasar/aws_dms.py
@@ -24,9 +24,10 @@ def check_refresh_status(aws_arn):
                                           'ReplicationTasks.0.StopReason')
     refresh_status['progress'] = pydash.get(task_progess,
                                             'ReplicationTasks.0.ReplicationTaskStats.FullLoadProgressPercent')
+    
     if (refresh_status['status'] == 'stopped' and
-        refresh_status['reason'] == 'Stop Reason FULL_LOAD_ONLY_FINISHED' and
-        refresh_status['progress'] == 100):
+            refresh_status['reason'] == 'Stop Reason FULL_LOAD_ONLY_FINISHED' and
+            refresh_status['progress'] == 100):
         return True
     else:
         return False

--- a/quasar/aws_dms.py
+++ b/quasar/aws_dms.py
@@ -1,5 +1,7 @@
 import boto3
 import pydash
+import time
+
 
 dms = boto3.client('dms')
 
@@ -22,20 +24,21 @@ def check_refresh_status(aws_arn):
                                           'ReplicationTasks.0.StopReason')
     refresh_status['progress'] = pydash.get(task_progess,
                                             'ReplicationTasks.0.ReplicationTaskStats.FullLoadProgressPercent')
-    if (status['status'] == 'stopped' and
-        status['reason'] == 'Stop Reason FULL_LOAD_ONLY_FINISHED' and
-        status['progress'] == 100):
+    if (refresh_status['status'] == 'stopped' and
+            refresh_status['reason'] == 'Stop Reason FULL_LOAD_ONLY_FINISHED'
+            and refresh_status['progress'] == 100):
         return True
     else:
         return False
 
+
 def refresh_finished(aws_arn):
     # Return true only when refresh is finished.
-    status = check_refresh_status()
-    while not check_refresh_status(aws_arn):
+    status = check_refresh_status(aws_arn)
+    while not status:
         # SLeep between checks for 60 seconds, then try again.
-        print("DMS refresh still not done, checking in 60.")
+        print("DMS refresh still not done, checking in 60 seconds.")
         time.sleep(60)
-        status = check_refresh_status()
+        status = check_refresh_status(aws_arn)
     print("DMS finished!")
     return None

--- a/quasar/refresh_bertly.py
+++ b/quasar/refresh_bertly.py
@@ -1,0 +1,14 @@
+import os
+import time
+from .aws_dms import start_dms_refresh, refresh_finished
+
+
+def main():
+    bertly_dms = os.environ.get('BERTLY_DMS_ARN')
+    start_dms_refresh(bertly_dms)
+    time.sleep(10)
+    refresh_finished(bertly_dms)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,12 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="0.8.0",
+    version="0.8.3",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={
         'console_scripts': [
+            'bertly_refresh = quasar.refresh_bertly:main',
             'campaign_info_table_refresh = quasar.phoenix_to_campaign_info_table:main',
             'campaign_info_recreate_pg = quasar.ashes_to_campaign_info:create',
             'campaign_info_refresh_pg = quasar.ashes_to_campaign_info:main',


### PR DESCRIPTION
#### What's this PR do?
* Refreshes sms_click data from Bertly by kicking of DMS full refresh.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/bertly-refresh?expand=1#diff-1830236ee3d3073b76b0bee40244fc93
#### How should this be manually tested?
Tested against DMS instance live multiple times.
#### Any background context you want to provide?
* This is a workaround until AWS can fix perpetual replication.
* We also still likely need a Mat View to make sure derived tables from this are not blocked by DB refreshes, which drops the whole source table.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/157194637

