### PR TITLE
Bertly Mat View Refresh and Env Vars for DB Class

### DIFF
--- a/quasar/database_mysql.py
+++ b/quasar/database_mysql.py
@@ -1,0 +1,80 @@
+import MySQLdb
+import MySQLdb.converters
+
+from .config import config
+from .utils import QuasarException
+
+
+def dec_to_float_converter():
+    converter = MySQLdb.converters.conversions.copy()
+    converter[246] = float
+    return converter
+
+
+def _connect(opts):
+    conn = None
+    try:
+        conn = MySQLdb.connect(**opts)
+    except MySQLdb.InterfaceError as e:
+        raise QuasarException(e)
+    finally:
+        return conn
+
+
+class Database:
+
+    def __init__(self, options={}):
+
+        # Defaults
+        opts = {
+            'user': config.MYSQL_USER,
+            'host': config.MYSQL_HOST,
+            'port': config.MYSQL_PORT,
+            'passwd': config.MYSQL_PASSWORD,
+            'db': config.MYSQL_DATABASE,
+            'ssl': config.MYSQL_SSL,
+            'use_unicode': True,
+            'charset': 'utf8'
+        }
+
+        opts.update(options)
+
+        self.connection = _connect(opts)
+        if self.connection is None:
+            print("Error, couldn't connect to database with options:", opts)
+        else:
+            self.cursor = self.connection.cursor()
+            if 'conv' in opts:
+                self.cursor = self.connection.cursor(
+                    MySQLdb.cursors.DictCursor)
+
+    def disconnect(self):
+        self.cursor.close()
+        self.connection.close()
+        return self.connection
+
+    def query(self, query):
+        """Parse and run DB query.
+
+        Return On error, raise exception and log why.
+        """
+        try:
+            self.cursor.execute(query)
+            self.connection.commit()
+            results = self.cursor.fetchall()
+            return results
+        except MySQLdb.DatabaseError as e:
+            raise QuasarException(e)
+
+    def query_str(self, query, string):
+        """Parse and run DB query.
+
+        Return On error, raise exception and log why.
+        """
+        try:
+            self.cursor.execute(query, string)
+            self.connection.commit()
+            results = self.cursor.fetchall()
+            return results
+        except MySQLdb.DatabaseError as e:
+            raise QuasarException(e)

--- a/quasar/refresh_bertly.py
+++ b/quasar/refresh_bertly.py
@@ -3,6 +3,7 @@ import time
 from .aws_dms import start_dms_refresh, refresh_finished
 from .database import Database
 
+
 def main():
     bertly_dms = os.environ.get('BERTLY_DMS_ARN')
     start_dms_refresh(bertly_dms)

--- a/quasar/refresh_bertly.py
+++ b/quasar/refresh_bertly.py
@@ -1,14 +1,7 @@
-import os
-import time
-from .aws_dms import start_dms_refresh, refresh_finished
 from .database import Database
 
 
 def main():
-    bertly_dms = os.environ.get('BERTLY_DMS_ARN')
-    start_dms_refresh(bertly_dms)
-    time.sleep(10)
-    refresh_finished(bertly_dms)
     db = Database()
     print('Refreshing Bertly Clicks materialized view.')
     db.query('REFRESH MATERIALIZED VIEW public.bertly_clicks')

--- a/quasar/refresh_bertly.py
+++ b/quasar/refresh_bertly.py
@@ -1,13 +1,16 @@
 import os
 import time
 from .aws_dms import start_dms_refresh, refresh_finished
-
+from .database import Database
 
 def main():
     bertly_dms = os.environ.get('BERTLY_DMS_ARN')
     start_dms_refresh(bertly_dms)
     time.sleep(10)
     refresh_finished(bertly_dms)
+    db = Database()
+    print('Refreshing Bertly Clicks materialized view.')
+    db.query('REFRESH MATERIALIZED VIEW public.bertly_clicks')
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="0.8.3",
+    version="0.9.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
1. Updates base DB class to use environment variables and be Postgres based.
2. Adds Bertly Mat View refresh to bertly refresh ETL.
3. Moves old MySQL DB class to `database_mysql.py`.
4. Version bump to `0.9.0`
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/refresh-bertly-mat-view?expand=1#diff-2a50a0134e43e26481e65977d62a7c35
#### How should this be manually tested?
Tested manually and it works. 
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/158126302

