### PR TITLE
Remove MySQL references in consumers.

### DIFF
--- a/quasar/cio_consumer_pg.py
+++ b/quasar/cio_consumer_pg.py
@@ -1,7 +1,7 @@
-from .quasar_queue import CioPostgresQueue
+from .quasar_queue import CioQueue
 
 
-queue = CioPostgresQueue()
+queue = CioQueue()
 
 
 def main():

--- a/quasar/cio_queue_process.py
+++ b/quasar/cio_queue_process.py
@@ -1,9 +1,0 @@
-from .config import config
-from .quasar_queue import CioQueue
-
-
-queue = CioQueue()
-
-
-def main():
-    queue.start_consume()

--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -1,90 +1,46 @@
 import json
 import pydash
+import os
 import sys
 
-from .config import config
-from .database_mysql import Database
-from .database_pg import Database as DatabasePG
+from .database import Database
 from .queue import QuasarQueue
 from .utils import unixtime_to_isotime as u2i
 from .utils import strip_str
 
 
-class CioQueue(QuasarQueue):
+class RouteQueue(QuasarQueue):
 
     def __init__(self):
-        super().__init__(config.AMQP_URI, config.BLINK_QUEUE,
-                         config.BLINK_EXCHANGE)
+        self.amqp_uri = os.environ.get('AMQP_URI')
+        self.blink_queue = os.environ.get('BLINK_QUEUE')
+        self.blink_exchange = os.environ.get('BLINK_EXCHANGE')
+        super().__init__(self.amqp_uri, self.blink_queue,
+                         self.blink_exchange)
         self.rogue_queue = RogueQueue()
-        self.rogue_pg_queue = RoguePostgresQueue()
-        self.cio_pg_queue = CioPostgresQueue()
+        self.cio_queue = CioQueue()
         self.db = Database()
 
     def process_message(self, message_data):
         if pydash.get(message_data, 'data.meta.message_source') == 'rogue':
             print("Routing message to Rogue queue.")
             self.rogue_queue.pub_message(message_data)
-            self.rogue_pg_queue.pub_message(message_data)
         else:
             print(''.join(("Publishing C.IO event id:"
                            "{} to c.io Postgres queue."
                            "")).format(message_data['data']['event_id']))
-            self.cio_pg_queue.pub_message(message_data)
-            print(''.join(("Processing C.IO event id: "
-                           "{}.")).format(message_data['data']['event_id']))
-            self.log_event(message_data)
-            self.customer_event(message_data)
-            event_type = message_data['data']['event_type']
-            if (event_type == 'customer_subscribed' or
-                    event_type == 'customer_unsubscribed'):
-                self.legacy_sub_unsub(message_data)
-
-    def log_event(self, message_data):
-        self.db.query_str(''.join(("INSERT INTO cio.event_log"
-                          "(meta, data) VALUES (%s, %s)")),
-                          (json.dumps(message_data['meta']),
-                           json.dumps(message_data['data'])))
-
-    def customer_event(self, message_data):
-        self.db.query_str(''.join(("INSERT INTO cio.customer_event "
-                                   "VALUES (%s, %s, %s, %s)")),
-                          (message_data['data']['event_type'],
-                           message_data['data']['event_id'],
-                           u2i(message_data['data']['timestamp']),
-                           message_data['data']['data']['customer_id']))
-
-    def legacy_sub_unsub(self, message_data):
-        email = message_data['data']['data']['email_address']
-        nsid = self.db.query_str(''.join(("SELECT northstar_id "
-                                          "FROM quasar.users "
-                                          "WHERE email = %s")),
-                                 (email,))
-        if message_data['data']['event_type'] == 'customer_subscribed':
-            status = 'subscribed'
-        else:
-            status = 'unsubscribed'
-        if strip_str(nsid) != "":
-            self.db.query_str(''.join(("UPDATE quasar.users SET "
-                                       "customer_io_subscription_status = %s,"
-                                       "customer_io_subscription_timestamp "
-                                       " = %s WHERE northstar_id = %s")),
-                              (status,
-                               u2i(message_data['data']['timestamp']),
-                               strip_str(nsid)))
-        else:
-            self.db.query_str(''.join(("INSERT INTO cio.legacy_sub_backlog "
-                                       "VALUES (%s, %s, %s)")),
-                              (status,
-                               u2i(message_data['data']['timestamp']),
-                               message_data['data']['data']['customer_id']))
+            self.cio_queue.pub_message(message_data)
 
 
-class CioPostgresQueue(QuasarQueue):
+class CioQueue(QuasarQueue):
 
     def __init__(self):
-        super().__init__(config.AMQP_URI, config.CIO_PG_QUEUE,
-                         config.QUASAR_EXCHANGE)
-        self.db = DatabasePG()
+        self.amqp_uri = os.environ.get('AMQP_URI')
+        self.cio_queue = os.environ.get('CIO_QUEUE')
+        self.quasar_exchange = os.environ.get('QUASAR_EXCHANGE')
+        super().__init__(self.amqp_uri, self.cio_queue,
+                         self.quasar_exchange)
+        self.db = Database()
 
     # Save entire c.io JSON blob to event_log table.
     def _log_event(self, data):
@@ -218,150 +174,12 @@ class CioPostgresQueue(QuasarQueue):
 class RogueQueue(QuasarQueue):
 
     def __init__(self):
-        super().__init__(config.AMQP_URI, config.ROGUE_QUEUE,
-                         config.QUASAR_EXCHANGE)
+        self.amqp_uri = os.environ.get('AMQP_URI')
+        self.rogue_queue = os.environ.get('ROGUE_QUEUE')
+        self.quasar_exchange = os.environ.get('QUASAR_EXCHANGE')
+        super().__init__(self.amqp_uri, self.rogue_queue,
+                         self.quasar_exchange)
         self.db = Database()
-        self.campaign_activity_table = config.CAMPAIGN_ACTIVITY_TABLE
-        self.campaign_activity_log_table = config.CAMPAIGN_ACTIVITY_LOG_TABLE
-        self.campaign_activity_details = config.CAMPAIGN_ACTIVITY_DETAIL_TABLE
-
-    def _add_signup(self, signup_data):
-        self.db.query_str(''.join(("REPLACE INTO ",
-                                   self.campaign_activity_table,
-                                   " SET northstar_id = %s, "
-                                   "signup_id = %s, campaign_id = %s, "
-                                   "campaign_run_id = %s, quantity = %s, "
-                                   "why_participated = %s, "
-                                   "signup_source = %s, signup_details = %s, "
-                                   "signup_created_at = %s, "
-                                   "signup_updated_at = %s, "
-                                   "post_id = -1, url = NULL, "
-                                   "caption = NULL, status = NULL, "
-                                   "remote_addr = NULL, post_source = NULL, "
-                                   "submission_created_at = ''")),
-                          (signup_data['northstar_id'],
-                           signup_data['signup_id'],
-                           signup_data['campaign_id'],
-                           signup_data['campaign_run_id'],
-                           signup_data['quantity'],
-                           signup_data['why_participated'],
-                           signup_data['signup_source'],
-                           signup_data['details'],
-                           signup_data['created_at'],
-                           signup_data['updated_at']))
-        print("Signup {} ETL'd.".format(signup_data['signup_id']))
-
-    def _delete_signup(self, signup_id, deleted_at):
-        # Set signup status to 'deleted'.
-        self.db.query_str(''.join(("UPDATE ",
-                                   self.campaign_activity_table,
-                                   " SET status = %s, "
-                                   "signup_updated_at = %s "
-                                   "WHERE signup_id = %s")),
-                          ('signup_deleted', deleted_at, signup_id))
-        # Copy signup into campaign_activity_log table.
-        self.db.query_str(''.join(("INSERT IGNORE INTO ",
-                                   self.campaign_activity_log_table,
-                                   " SELECT * FROM ",
-                                   self.campaign_activity_table,
-                                   " WHERE signup_id = %s AND "
-                                   "signup_updated_at = %s")),
-                          (signup_id, deleted_at))
-        # Delete signup from campaign_activity table.
-        self.db.query_str(''.join(("DELETE FROM ",
-                                   self.campaign_activity_table,
-                                   " WHERE status = %s AND "
-                                   "signup_id = %s AND "
-                                   "signup_updated_at = %s")),
-                          ('signup_deleted', signup_id, deleted_at))
-        print("Signup {} deleted and archived.".format(signup_id))
-
-    def _add_post(self, post_data):
-        self.db.query_str(''.join(("REPLACE INTO ",
-                                   self.campaign_activity_table,
-                                   " SET northstar_id = %s, "
-                                   "signup_id = %s, campaign_id = %s, "
-                                   "campaign_run_id = %s, quantity = %s, "
-                                   "why_participated = %s,"
-                                   "signup_source = %s, "
-                                   "signup_created_at = %s, "
-                                   "signup_updated_at = %s, "
-                                   "post_id = %s, url = %s, caption = %s, "
-                                   "status = %s, remote_addr = %s, "
-                                   "post_source = %s, "
-                                   "submission_created_at = %s, "
-                                   "submission_updated_at = %s, "
-                                   "action = %s, post_type = %s")),
-                          (post_data['northstar_id'],
-                           post_data['signup_id'],
-                           post_data['campaign_id'],
-                           post_data['campaign_run_id'],
-                           post_data['quantity'],
-                           post_data['why_participated'],
-                           post_data['signup_source'],
-                           post_data['signup_created_at'],
-                           post_data['signup_updated_at'],
-                           post_data['id'],
-                           post_data['media']['url'],
-                           post_data['media']['caption'],
-                           post_data['status'],
-                           post_data['remote_addr'],
-                           post_data['source'],
-                           post_data['created_at'],
-                           post_data['updated_at'],
-                           post_data['action'],
-                           post_data['type']))
-        print("Post {} ETL'd.".format(post_data['id']))
-
-    def _delete_post(self, post_id, deleted_at):
-        # Set post status to 'deleted'.
-        self.db.query_str(''.join(("UPDATE ",
-                                   self.campaign_activity_table,
-                                   " SET status = %s, "
-                                   "submission_updated_at = %s, "
-                                   "signup_updated_at = %s "
-                                   "WHERE post_id = %s")),
-                          ('deleted', deleted_at, deleted_at, post_id))
-        # Copy post into campaign_activity_log table.
-        self.db.query_str(''.join(("INSERT IGNORE INTO ",
-                                   self.campaign_activity_log_table,
-                                   " SELECT * FROM ",
-                                   self.campaign_activity_table,
-                                   " WHERE post_id = %s AND "
-                                   "submission_updated_at = %s")),
-                          (post_id, deleted_at))
-        # Delete record from campaign_activity table.
-        self.db.query_str(''.join(("DELETE FROM ",
-                                   self.campaign_activity_table,
-                                   " WHERE status = %s AND "
-                                   "post_id = %s AND "
-                                   "signup_updated_at = %s")),
-                          ('deleted', post_id, deleted_at))
-        print("Post {} deleted and archived.".format(post_id))
-
-    def process_message(self, message_data):
-        data = message_data['data']
-        if data['meta']['type'] == 'signup':
-            if not pydash.get(data, 'deleted_at'):
-                self._add_signup(data)
-            else:
-                self._delete_signup(data['id'], data['deleted_at'])
-        elif data['meta']['type'] == 'post':
-            if not pydash.get(data, 'deleted_at'):
-                self._add_post(data)
-            else:
-                self._delete_post(data['id'], data['deleted_at'])
-        else:
-            print("Unknown rogue message type. Exiting.")
-            sys.exit(1)
-
-
-class RoguePostgresQueue(QuasarQueue):
-
-    def __init__(self):
-        super().__init__(config.AMQP_URI, config.ROGUE_PG_QUEUE,
-                         config.QUASAR_EXCHANGE)
-        self.db = DatabasePG()
 
     def _add_signup(self, signup_data):
         self.db.query_str(''.join(("INSERT INTO rogue.signups "

--- a/quasar/queue.py
+++ b/quasar/queue.py
@@ -1,10 +1,10 @@
 import json
 import logging
+import os
 import time
 
 import pika
 
-from .config import config
 from .utils import QuasarException
 
 log_format = "%(asctime)s - %(levelname)s: %(message)s"
@@ -27,7 +27,8 @@ class QuasarQueue:
         self.params.socket_timeout = 5
         self.connection = pika.BlockingConnection(self.params)
         self.channel = self.connection.channel()
-        self.channel.basic_qos(prefetch_count=config.QUEUE_PREFETCH_COUNT)
+        self.queue_prefetch = os.environ.get('QUEUE_PREFETCH_COUNT')
+        self.channel.basic_qos(prefetch_count=self.queue_prefetch)
         self.channel.queue_declare(amqp_queue, durable=True,
                                    arguments={'x-max-priority': 2})
         self.channel.confirm_delivery()

--- a/quasar/rogue_consumer_pg.py
+++ b/quasar/rogue_consumer_pg.py
@@ -1,7 +1,7 @@
-from .quasar_queue import RoguePostgresQueue
+from .quasar_queue import RogueQueue
 
 
-queue = RoguePostgresQueue()
+queue = RogueQueue()
 
 
 def main():

--- a/quasar/route_queue_process.py
+++ b/quasar/route_queue_process.py
@@ -1,0 +1,8 @@
+from .quasar_queue import RouteQueue
+
+
+queue = RouteQueue()
+
+
+def main():
+    queue.start_consume()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="0.9.0",
+    version="0.9.1",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={
@@ -15,7 +15,6 @@ setup(
             'campaign_info_recreate_pg = quasar.ashes_to_campaign_info:create',
             'campaign_info_refresh_pg = quasar.ashes_to_campaign_info:main',
             'campaign_activity_refresh = quasar.refresh_campaign_activity:main',
-            'cio_import = quasar.cio_queue_process:main',
             'cio_import_pg = quasar.cio_consumer_pg:main',
             'etl_monitoring = quasar.etl_monitoring:run_monitoring',
             'get_competitions = quasar.gladiator_import:get_competitions',
@@ -23,6 +22,7 @@ setup(
             'member_event_log = quasar.member_event_log:mel',
             'mel_create_pg = quasar.mel:create',
             'mel_refresh_pg = quasar.mel:main',
+            'message_route = quasar.route_queue_process:main',
             'northstar_to_quasar_import_backfill = quasar.northstar_to_user_table:backfill_since',
             'northstar_to_quasar_diff_pg = quasar.northstar_to_user_table_pg:backfill_since',
             'quasar_blink_queue_consumer = quasar.customerio:main',


### PR DESCRIPTION
#### What's this PR do?
* Remove CIO MySQL DB processing as pre-req step to routing messages to their own dedicated queues for CIO and Rogue.
* Renames and updates previous CIO MySQL consumer/router to be a simple routing consumer/publisher.
* Removes MySQL based consumers in `quasar_queue` library.
* Updates all consumers to use new env var `Database` class.
* Updates `Postgres` naming differentiation for consumers, since we no longer have MySQL in play.
* Updates all consumers to use env vars instead of deprecatable `config` class.
* Bumps Quasar to version `0.9.1`.

#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/mysql-remove?expand=1#diff-68da9c0535d3768969007f65eaf1ffd9
#### How should this be manually tested?
Tested local connections and works properly.
#### Any background context you want to provide?
We need to spin down MySQL Quasar servers which are costing a lot of money. And this is the final code that is blocking that endeavor, and hopefully gonging in the migration.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/158196510

