### PR TITLE
Need to cast pre-fetch count as int.

### DIFF
--- a/quasar/queue.py
+++ b/quasar/queue.py
@@ -28,7 +28,7 @@ class QuasarQueue:
         self.connection = pika.BlockingConnection(self.params)
         self.channel = self.connection.channel()
         self.queue_prefetch = os.environ.get('QUEUE_PREFETCH_COUNT')
-        self.channel.basic_qos(prefetch_count=self.queue_prefetch)
+        self.channel.basic_qos(prefetch_count=int(self.queue_prefetch))
         self.channel.queue_declare(amqp_queue, durable=True,
                                    arguments={'x-max-priority': 2})
         self.channel.confirm_delivery()


### PR DESCRIPTION
#### What's this PR do?
Pre-fetch count needs to be cast as int for environment variable to be read properly.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/quasar-prefetch-hotfix?expand=1#diff-e1305226d75bdf2c81cba0ac0d8bc1d6
#### How should this be manually tested?
You know...live.

