### PR TITLE
Adding source_details to rogue signups and posts.

### DIFF
--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -185,10 +185,11 @@ class RogueQueue(QuasarQueue):
         self.db.query_str(''.join(("INSERT INTO rogue.signups "
                                    "(id, northstar_id, campaign_id, "
                                    "campaign_run_id, quantity, "
-                                   "why_participated, source, details, "
+                                   "why_participated, source, "
+                                   "source_details, details, "
                                    "created_at, updated_at) "
                                    "VALUES (%s,%s,%s,%s,%s,%s,"
-                                   "%s,%s,%s,%s) ON CONFLICT "
+                                   "%s,%s,%s,%s,%s) ON CONFLICT "
                                    "(id, updated_at) "
                                    "DO NOTHING")),
                           (signup_data['signup_id'],
@@ -198,6 +199,7 @@ class RogueQueue(QuasarQueue):
                            signup_data['quantity'],
                            signup_data['why_participated'],
                            signup_data['signup_source'],
+                           signup_data['source_details'],
                            signup_data['details'],
                            signup_data['created_at'],
                            signup_data['updated_at']))
@@ -219,10 +221,11 @@ class RogueQueue(QuasarQueue):
                                    "(id, signup_id, campaign_id, "
                                    "northstar_id, "
                                    "type, action, quantity, url, caption, "
-                                   "status, source, signup_source, "
+                                   "status, source, "
+                                   "source_details, signup_source, "
                                    "remote_addr, created_at, "
                                    "updated_at) VALUES "
-                                   "(%s,%s,%s,%s,%s,%s,%s,%s,"
+                                   "(%s,%s,%s,%s,%s,%s,%s,%s,%s,"
                                    "%s,%s,%s,%s,%s,%s,%s) ON CONFLICT "
                                    "DO NOTHING")),
                           (post_data['id'],
@@ -236,6 +239,7 @@ class RogueQueue(QuasarQueue):
                            post_data['media']['caption'],
                            post_data['status'],
                            post_data['source'],
+                           post_data['source_details'],
                            post_data['signup_source'],
                            post_data['remote_addr'],
                            post_data['created_at'],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="0.9.2",
+    version="0.9.3",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
* Adds `source_details` field ingestion to Rogue posts and signups tables.
* Bumps Quasar version to `0.9.3`.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/rogue-signup-source-detail?expand=1#diff-68da9c0535d3768969007f65eaf1ffd9

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/158636458

