### PR TITLE
Multi-Small-Hotfix

### DIFF
--- a/quasar/northstar_to_user_table_pg.py
+++ b/quasar/northstar_to_user_table_pg.py
@@ -45,8 +45,8 @@ class NorthstarDB:
                                    "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,"
                                    "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,"
                                    "%s,%s,%s,%s,%s,%s,%s,%s,%s) "
-                                   "ON CONFLICT (id, created_at, updated_at)"
-                                   " DO NOTHING")),
+                                   "ON CONFLICT (id, created_at, updated_at, "
+                                   "voter_registration_status) DO NOTHING")),
                           (user['id'], user['first_name'],
                            user['last_name'], user['last_initial'],
                            user['photo'], user['email'], user['mobile'],

--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -185,10 +185,9 @@ class RogueQueue(QuasarQueue):
         self.db.query_str(''.join(("INSERT INTO rogue.signups "
                                    "(id, northstar_id, campaign_id, "
                                    "campaign_run_id, quantity, "
-                                   "why_participated, source, "
-                                   "source_details, details, "
+                                   "why_participated, source, details, "
                                    "created_at, updated_at) "
-                                   "VALUES (%s,%s,%s,%s,%s,%s,"
+                                   "VALUES (%s,%s,%s,%s,%s,"
                                    "%s,%s,%s,%s,%s) ON CONFLICT "
                                    "(id, updated_at) "
                                    "DO NOTHING")),
@@ -199,7 +198,6 @@ class RogueQueue(QuasarQueue):
                            signup_data['quantity'],
                            signup_data['why_participated'],
                            signup_data['signup_source'],
-                           signup_data['source_details'],
                            signup_data['details'],
                            signup_data['created_at'],
                            signup_data['updated_at']))
@@ -221,11 +219,10 @@ class RogueQueue(QuasarQueue):
                                    "(id, signup_id, campaign_id, "
                                    "northstar_id, "
                                    "type, action, quantity, url, caption, "
-                                   "status, source, "
-                                   "source_details, signup_source, "
+                                   "status, source, signup_source, "
                                    "remote_addr, created_at, "
                                    "updated_at) VALUES "
-                                   "(%s,%s,%s,%s,%s,%s,%s,%s,%s,"
+                                   "(%s,%s,%s,%s,%s,%s,%s,%s,"
                                    "%s,%s,%s,%s,%s,%s,%s) ON CONFLICT "
                                    "DO NOTHING")),
                           (post_data['id'],
@@ -239,7 +236,6 @@ class RogueQueue(QuasarQueue):
                            post_data['media']['caption'],
                            post_data['status'],
                            post_data['source'],
-                           post_data['source_details'],
                            post_data['signup_source'],
                            post_data['remote_addr'],
                            post_data['created_at'],


### PR DESCRIPTION
#### What's this PR do?
* Add's `voter_registration_status` as a column to update on temporarily to backfill records with `voter_registration_status`, since we've already ingested users with those records, and their `updated_at` records aren't triggering row updates.
* Removes previous PR changes to Rogue `source_detail` fields, since they aren't in Production yet. Will put in another branch for those changes to merge once they are.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/voter-reg-and-other-hotfix?expand=1#diff-f5fda895762fcf4b0cd17a08b722fc1e


#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/158602297

