### PR TITLE
Reverting normal NS scraper and adding JSON capture for voter reg records

### DIFF
--- a/quasar/northstar_to_user_table_pg.py
+++ b/quasar/northstar_to_user_table_pg.py
@@ -88,8 +88,10 @@ def _interval(hours_ago):
 def backfill_since():
     _backfill(sys.argv[1])
 
+
 def backfill_since_json():
     _backfill(sys.argv[1], sys.argv[2])
+
 
 def _backfill(hours_ago=None, store_json=False):
     start_time = time.time()

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
             'message_route = quasar.route_queue_process:main',
             'northstar_to_quasar_import_backfill = quasar.northstar_to_user_table:backfill_since',
             'northstar_to_quasar_diff_pg = quasar.northstar_to_user_table_pg:backfill_since',
+            'northstar_to_quasar_voter_reg = quasar.northstar_to_user_table_pg:backfill_voter_reg_since',
             'quasar_blink_queue_consumer = quasar.customerio:main',
             'phoenix_next_cleanup = quasar.phoenix_next_queue_cleanup:main',
             'puck_refresh = quasar.puck_events:main',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
             'message_route = quasar.route_queue_process:main',
             'northstar_to_quasar_import_backfill = quasar.northstar_to_user_table:backfill_since',
             'northstar_to_quasar_diff_pg = quasar.northstar_to_user_table_pg:backfill_since',
-            'northstar_to_quasar_voter_reg = quasar.northstar_to_user_table_pg:backfill_voter_reg_since',
+            'northstar_to_quasar_diff_json = quasar.northstar_to_user_table_pg:backfill_since_json',
             'quasar_blink_queue_consumer = quasar.customerio:main',
             'phoenix_next_cleanup = quasar.phoenix_next_queue_cleanup:main',
             'puck_refresh = quasar.puck_events:main',


### PR DESCRIPTION
#### What's this PR do?
Oi, hate hacky PR's like this, but needed to be a bit expedient.
* Reverts Northstar scraper to normal place, since voter_reg_status as conflict didn't work. :/
* Adds duplicate functions to capture raw json that can then update the `northstar.users` table via direct query.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/voter-reg-fix?expand=1#diff-f5fda895762fcf4b0cd17a08b722fc1e

