### PR TITLE
bertly channels are properly attributed based on bertly source

### DIFF
--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -173,14 +173,14 @@ FROM (
     AND pe.northstar_id IS NOT NULL
     AND pe.northstar_id <> ''
     UNION ALL 
-    SELECT DISTINCT -- SMS LINK CLICKS FROM BERTLY -- is bertly still only used for sms links? 
+    SELECT DISTINCT -- SMS LINK CLICKS FROM BERTLY 
         b.northstar_id AS northstar_id,
         b.click_time AS "timestamp",
-        'sms_link_click' AS "action",
+        'bertly_link_click' AS "action",
         '10' AS action_id,
         'bertly' AS "source",
         b.click_id AS action_serial_id,
-        'sms' AS "channel"
+        b."source" AS "channel"
     FROM public.bertly_clicks b 
     WHERE b.northstar_id IS NOT NULL
       ) AS a 


### PR DESCRIPTION
#### What's this PR do?
* Updates the MEL to properly name bertly actions and set the channel using public.bertly_clicks.source

#### Where should the reviewer start?
* mel.sql

#### How should this be manually tested?
* Does the channel value update in MEL?

#### Any background context you want to provide?
* Bertly is being used over web and sms. When it is web, the target url contains the phrase source=web. We've parsed this out into public.bertly_clicks.source. This value allows us to properly do channel attribution in the MEL

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/159376016

#### Screenshots (if appropriate)
#### Questions:
