### PR TITLE
Phoenix campaigns

### DIFF
--- a/quasar/campaign_info.py
+++ b/quasar/campaign_info.py
@@ -1,0 +1,6 @@
+import os
+from .database import Database
+from .ds_oauth_scraper import DSOAuthScraper
+
+scraper = 
+

--- a/quasar/campaign_info.py
+++ b/quasar/campaign_info.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import sys
+
 from .database import Database
 from .ds_oauth_scraper import DSOAuthScraper
 
@@ -19,10 +21,17 @@ def update_campaign_info():
     try:
         for id in ids:
             path = os.getenv('PHOENIX_CAMPAIGN_API_PATH') + id[0]
-            info = scraper.get(path).json()
-            logging.info('Scraped ID %s.', (id[0]))
+            result = scraper.get(path)
+            if result.status_code == 200:
+                info = result.json()
+                logging.info('Scraped campaign {}.'.format((id[0])))
+            else:
+                logging.error(''.join(('{} status code returned for campaign '
+                                      '{}.'.format(result.status_code, id[0]))))
     except:
-        logging.info('Ruh ruh, something went wrong!')
+        logging.info('Something went wrong!')
+        logging.info('Exiting on campaign {}.'.format((id[0])))
+        sys.exit(1)
 
 
 def main():

--- a/quasar/campaign_info.py
+++ b/quasar/campaign_info.py
@@ -10,6 +10,7 @@ logging.getLogger().setLevel(logging.INFO)
 scraper = DSOAuthScraper(os.getenv('PHOENIX_URI'))
 db = Database()
 
+
 def refresh_campaign_ids():
     # Refresh list of campaign id's to scrape from Rogue signups.
     db.query("REFRESH MATERIALIZED VIEW phoenix.campaign_ids")
@@ -20,7 +21,7 @@ def update_campaign_info():
     refresh_campaign_ids()
     ids = db.query('SELECT * FROM phoenix.campaign_ids')
     # Remove all stale entries to ensure latest good data.
-    db.query("TRUNCATE phoenix.campaigns_json")    
+    db.query("TRUNCATE phoenix.campaigns_json")
     # Query each campaign id currently active from Phoenix campaign api.
     try:
         for id in ids:
@@ -37,7 +38,8 @@ def update_campaign_info():
 
             else:
                 logging.error(''.join(('{} status code returned for campaign '
-                                      '{}.'.format(result.status_code, id[0]))))
+                                      '{}.'.format(result.status_code,
+                                                   id[0]))))
     except:
         logging.info('Something went wrong!')
         logging.info('Exiting on campaign {}.'.format((id[0])))

--- a/quasar/campaign_info.py
+++ b/quasar/campaign_info.py
@@ -1,6 +1,34 @@
+import json
+import logging
 import os
 from .database import Database
 from .ds_oauth_scraper import DSOAuthScraper
 
-scraper = 
+logging.getLogger().setLevel(logging.INFO)
+scraper = DSOAuthScraper(os.getenv('PHOENIX_URI'))
+db = Database()
 
+def refresh_campaign_ids():
+    db.query("REFRESH MATERIALIZED VIEW phoenix.campaign_ids")
+    logging.info('Phoenix campaigns have been refreshed from rogue.signups.')
+
+
+def update_campaign_info():
+    refresh_campaign_ids()
+    ids = db.query('SELECT * FROM phoenix.campaign_ids')
+    try:
+        for id in ids:
+            path = os.getenv('PHOENIX_CAMPAIGN_API_PATH') + id[0]
+            info = scraper.get(path).json()
+            logging.info('Scraped ID %s.', (id[0]))
+    except:
+        logging.info('Ruh ruh, something went wrong!')
+
+
+def main():
+    update_campaign_info()
+    db.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/quasar/campaign_info.py
+++ b/quasar/campaign_info.py
@@ -11,6 +11,7 @@ scraper = DSOAuthScraper(os.getenv('PHOENIX_URI'))
 db = Database()
 
 def refresh_campaign_ids():
+    # Refresh list of campaign id's to scrape from Rogue signups.
     db.query("REFRESH MATERIALIZED VIEW phoenix.campaign_ids")
     logging.info('Phoenix campaigns have been refreshed from rogue.signups.')
 
@@ -18,6 +19,9 @@ def refresh_campaign_ids():
 def update_campaign_info():
     refresh_campaign_ids()
     ids = db.query('SELECT * FROM phoenix.campaign_ids')
+    # Remove all stale entries to ensure latest good data.
+    db.query("TRUNCATE phoenix.campaigns_json")    
+    # Query each campaign id currently active from Phoenix campaign api.
     try:
         for id in ids:
             path = os.getenv('PHOENIX_CAMPAIGN_API_PATH') + id[0]
@@ -25,6 +29,12 @@ def update_campaign_info():
             if result.status_code == 200:
                 info = result.json()
                 logging.info('Scraped campaign {}.'.format((id[0])))
+                # Insert raw json per campaign into db.
+                db.query_str(''.join(("INSERT INTO phoenix.campaigns_json "
+                                      "(campaign_data) VALUES (%s)")),
+                             (json.dumps(info),))
+                logging.info('Campaign {} added to db.'.format((id[0])))
+
             else:
                 logging.error(''.join(('{} status code returned for campaign '
                                       '{}.'.format(result.status_code, id[0]))))

--- a/quasar/ds_oauth_scraper.py
+++ b/quasar/ds_oauth_scraper.py
@@ -1,5 +1,3 @@
-import json
-import oauthlib
 from oauthlib.oauth2 import BackendApplicationClient
 import os
 from requests_oauthlib import OAuth2Session

--- a/quasar/ds_oauth_scraper.py
+++ b/quasar/ds_oauth_scraper.py
@@ -6,7 +6,7 @@ from requests_oauthlib import OAuth2Session
 from .scraper import Scraper
 
 
-class DSAuthScraper(Scraper):
+class DSOAuthScraper(Scraper):
 
     def __init__(self, url):
         Scraper.__init__(self, url)
@@ -14,11 +14,11 @@ class DSAuthScraper(Scraper):
 
     def fetch_auth_headers(self):
         oauth = OAuth2Session(client=BackendApplicationClient(
-            client_id=os.environ.get('NS_CLIENT_ID')))
+            client_id=os.getenv('NS_CLIENT_ID')))
         scopes = ['admin', 'user']
-        new_token = oauth.fetch_token(os.environ.get('NS_URI') + '/v2/auth/token',
-                                      client_id=os.environ.get('NS_CLIENT_ID'),
-                                      client_secret=os.environ.get('NS_CLIENT_SECRET'),
+        new_token = oauth.fetch_token(os.getenv('NS_URI') + '/v2/auth/token',
+                                      client_id=os.getenv('NS_CLIENT_ID'),
+                                      client_secret=os.getenv('NS_CLIENT_SECRET'),
                                       scope=scopes)
         return {'Authorization': 'Bearer ' + str(new_token['access_token'])}
 

--- a/quasar/ds_oauth_scraper.py
+++ b/quasar/ds_oauth_scraper.py
@@ -1,0 +1,37 @@
+import json
+import oauthlib
+from oauthlib.oauth2 import BackendApplicationClient
+import os
+from requests_oauthlib import OAuth2Session
+from .scraper import Scraper
+
+
+class DSAuthScraper(Scraper):
+
+    def __init__(self, url):
+        Scraper.__init__(self, url)
+        self.auth_headers = self.fetch_auth_headers()
+
+    def fetch_auth_headers(self):
+        oauth = OAuth2Session(client=BackendApplicationClient(
+            client_id=os.environ.get('NS_CLIENT_ID')))
+        scopes = ['admin', 'user']
+        new_token = oauth.fetch_token(os.environ.get('NS_URI') + '/v2/auth/token',
+                                      client_id=os.environ.get('NS_CLIENT_ID'),
+                                      client_secret=os.environ.get('NS_CLIENT_SECRET'),
+                                      scope=scopes)
+        return {'Authorization': 'Bearer ' + str(new_token['access_token'])}
+
+    def authenticated(func):
+        def _authenticated(self, *args, **kwargs):
+            response = func(self, *args, **kwargs)
+            if response.status_code == 401:
+                self.auth_headers = self.fetch_auth_headers()
+                response = func(self, *args, **kwargs)
+            return response
+        return _authenticated
+
+    @authenticated
+    def get(self, path, query_params=''):
+        return super().get(path, headers=self.auth_headers,
+                           params=query_params)

--- a/quasar/refresh_bertly.py
+++ b/quasar/refresh_bertly.py
@@ -5,6 +5,7 @@ def main():
     db = Database()
     print('Refreshing Bertly Clicks materialized view.')
     db.query('REFRESH MATERIALIZED VIEW public.bertly_clicks')
+    db.disconnect()
 
 
 if __name__ == "__main__":

--- a/quasar/scraper.py
+++ b/quasar/scraper.py
@@ -1,6 +1,6 @@
+import json
 import requests
 from requests.packages.urllib3.util.retry import Retry
-from bs4 import BeautifulSoup as bs
 
 
 class Scraper:
@@ -31,7 +31,3 @@ class Scraper:
 
     def getJson(self, path, **args):
         return self.get(path, **args).json()
-
-    def getXml(self, path, **args):
-        response = self.get(path, **args)
-        return bs(response.text, 'xml')

--- a/quasar/scraper.py
+++ b/quasar/scraper.py
@@ -1,4 +1,3 @@
-import json
 import requests
 from requests.packages.urllib3.util.retry import Retry
 

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,14 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="1.3.0",
+    version="1.4.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={
         'console_scripts': [
             'bertly_refresh = quasar.refresh_bertly:main',
             'bertly_create = quasar.recreate_bertly:main',
+            'campaign_info = quasar.campaign_info:main',
             'campaign_info_recreate = quasar.ashes_to_campaign_info:create',
             'campaign_info_refresh = quasar.ashes_to_campaign_info:main',
             'campaign_activity_create = quasar.recreate_campaign_activity:main',


### PR DESCRIPTION
#### What's this PR do?
* Adds data pipeline to query for all campaigns id's from `rogue.signups` table, then query the Phoenix API for full campaign data. This is to replace our current Ashes based campaign_info table solution.
* Updates Scraper class to remove XML parsing, since that was legacy from MoCo days.
* Adds generic DS_OAUTH_Scraper class so that we can use Northstar auth to multiple services and key refreshes are automatically handled.
* Bumps version to `1.4.0`.
* Also now with 💯 more logging than we've ever had before instead of `print` statements!

#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/phoenix-campaigns?expand=1#diff-9c0c7201c8000c8539f08ed404e0c4b4
#### How should this be manually tested?
Tested in Quasar QA db with no issues.
#### Any background context you want to provide?
This is a medium-term solution until Phoenix is completely migrated to and there is a scrapable paginated API for all campaigns.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/159239490