### PR TITLE
Update Rogue conusmer to include post_id in post_details table.

### DIFF
--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -322,8 +322,8 @@ class RogueQueue(QuasarQueue):
             print("Turbovote details for post {} ETL'd.".format(post_id))
         else:
             self.db.query_str(''.join(("INSERT INTO rogue.post_details "
-                                       "(data) VALUES (%s)")),
-                              (post_details,))
+                                       "(data, post_id) VALUES (%s,%s)")),
+                              (post_details,post_id))
             print("Details for post {} ETL'd.".format(post_id))
 
     def process_message(self, message_data):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="1.4.0",
+    version="1.5.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
* Adds `post_id` to `post_details` table so Rogue post details can be correlated back to their post.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/post-details-id?expand=1#diff-68da9c0535d3768969007f65eaf1ffd9
#### How should this be manually tested?
* Test in Quasar QA, and works successfully.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/159403400

