### PR TITLE
web fb shares are coming from rogue, remove them from fbshare logic i…

### DIFF
--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -172,7 +172,7 @@ FROM (
         pe.event_name IN ('share action completed', 'facebook share posted')
     AND pe.northstar_id IS NOT NULL
     AND pe.northstar_id <> ''
-    AND to_timestamp(pe.ts /1000) <= '2018-08-07 14:00:00'
+    AND to_timestamp(pe.ts /1000) <= '2018-08-07 18:00:00'
     UNION ALL 
     SELECT DISTINCT -- SMS LINK CLICKS FROM BERTLY 
         b.northstar_id AS northstar_id,

--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -172,6 +172,7 @@ FROM (
         pe.event_name IN ('share action completed', 'facebook share posted')
     AND pe.northstar_id IS NOT NULL
     AND pe.northstar_id <> ''
+    AND to_timestamp(pe.ts /1000) <= '2018-08-07 14:00:00'
     UNION ALL 
     SELECT DISTINCT -- SMS LINK CLICKS FROM BERTLY 
         b.northstar_id AS northstar_id,


### PR DESCRIPTION
#### What's this PR do?
* Cuts off fb shares coming from puck in MEL

#### Where should the reviewer start?
* mel.sql

#### How should this be manually tested?
* run recreate MEL

#### Any background context you want to provide?
* Phoenix is sending web facebook shares directly to rogue. We don't want to double count them so we are removing them from the MEL

#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
