### PR TITLE
Updating references to relationized gambit_conversations tables to have _flattened appended to table names.

### DIFF
--- a/data/sql/derived-tables/gambit_conversations.sql
+++ b/data/sql/derived-tables/gambit_conversations.sql
@@ -1,12 +1,17 @@
 DROP MATERIALIZED VIEW IF EXISTS gambit_conversations.conversations_flattened;
 CREATE MATERIALIZED VIEW gambit_conversations.conversations_flattened AS
 (SELECT
-   (records->>'campaignId')::varchar as campaign_id, to_timestamp((((records->'createdAt'->>'$date')::BIGINT) / 1000)::double precision) as created_at,
-   (records->'_id'->>'$oid')::varchar as conversation_id, (records->>'importSource')::varchar as import_source,
-   (records->'lastOutboundMessage'->>'$oid')::varchar as last_outbound_message, (records->>'paused')::varchar as paused,
-   (records->>'platform')::varchar as platform, (records->>'platformUserId')::varchar as platform_user_id,
-   (records->>'topic')::varchar as topic, to_timestamp((((records->'updatedAt'->>'$date')::BIGINT) / 1000)::double precision) as updated_at,
-   (records->>'userId')::varchar as user_id from gambit_conversations.conversations_json);
+   (records->'campaignId')::varchar as campaign_id,
+   to_timestamp((((records->'createdAt'->>'$date')::BIGINT) / 1000)::double precision) as created_at,
+   (records->'_id'->>'$oid')::varchar as conversation_id,
+   (records->'importSource')::varchar as import_source,
+   (records->'lastOutboundMessage'->>'$oid')::varchar as last_outbound_message,
+   (records->'paused')::varchar as paused,
+   (records->'platform')::varchar as platform,
+   (records->'platformUserId')::varchar as platform_user_id,
+   (records->'topic')::varchar as topic,
+   to_timestamp((((records->'updatedAt'->>'$date')::BIGINT) / 1000)::double precision) as updated_at,
+   (records->'userId')::varchar as user_id from gambit_conversations.conversations_json);
 
 CREATE INDEX conversationidi on gambit_conversations.conversations_flattened(conversation_id);
 CREATE INDEX platformuidi on gambit_conversations.conversations_flattened(platform_user_id);

--- a/data/sql/derived-tables/gambit_conversations.sql
+++ b/data/sql/derived-tables/gambit_conversations.sql
@@ -1,5 +1,5 @@
-DROP MATERIALIZED VIEW IF EXISTS gambit_conversations.conversations;
-CREATE MATERIALIZED VIEW gambit_conversations.conversations AS
+DROP MATERIALIZED VIEW IF EXISTS gambit_conversations.conversations_flattened;
+CREATE MATERIALIZED VIEW gambit_conversations.conversations_flattened AS
 (SELECT
    (records->>'campaignId')::varchar as campaign_id, to_timestamp((((records->'createdAt'->>'$date')::BIGINT) / 1000)::double precision) as created_at,
    (records->'_id'->>'$oid')::varchar as conversation_id, (records->>'importSource')::varchar as import_source,
@@ -8,10 +8,10 @@ CREATE MATERIALIZED VIEW gambit_conversations.conversations AS
    (records->>'topic')::varchar as topic, to_timestamp((((records->'updatedAt'->>'$date')::BIGINT) / 1000)::double precision) as updated_at,
    (records->>'userId')::varchar as user_id from gambit_conversations.conversations_json);
 
-CREATE INDEX conversationidi on gambit_conversations.conversations(conversation_id);
-CREATE INDEX platformuidi on gambit_conversations.conversations(platform_user_id);
-CREATE INDEX useridi on gambit_conversations.conversations(user_id);
-CREATE INDEX topic on gambit_conversations.conversations(topic);
+CREATE INDEX conversationidi on gambit_conversations.conversations_flattened(conversation_id);
+CREATE INDEX platformuidi on gambit_conversations.conversations_flattened(platform_user_id);
+CREATE INDEX useridi on gambit_conversations.conversations_flattened(user_id);
+CREATE INDEX topic on gambit_conversations.conversations_flattened(topic);
 
-GRANT SELECT on gambit_conversations.conversations TO looker;
-GRANT SELECT on gambit_conversations.conversations to dsanalyst;
+GRANT SELECT on gambit_conversations.conversations_flattened TO looker;
+GRANT SELECT on gambit_conversations.conversations_flattened to dsanalyst;

--- a/data/sql/derived-tables/gambit_messages.sql
+++ b/data/sql/derived-tables/gambit_messages.sql
@@ -1,22 +1,27 @@
 DROP MATERIALIZED VIEW IF EXISTS gambit_conversations.messages_flattened CASCADE;
 CREATE MATERIALIZED VIEW gambit_conversations.messages_flattened AS
 (SELECT
-    (records->>'agentId')::VARCHAR as agent_id,
+    (records->'agentId')::VARCHAR as agent_id,
     ((records->'attachments')::JSONB->0->>'url')::VARCHAR as attachment_url,
     ((records->'attachments')::JSONB->0->>'contentType')::VARCHAR as attachment_content_type,
-    (records->>'broadcastId')::VARCHAR as broadcast_id, (records->>'campaignId')::VARCHAR as campaign_id,
+    (records->'broadcastId')::VARCHAR as broadcast_id,
+    (records->'campaignId')::VARCHAR as campaign_id,
     (records->'conversationId'->>'$oid')::VARCHAR as conversation_id,
     to_timestamp((((records->'createdAt'->>'$date')::BIGINT) / 1000)::DOUBLE PRECISION) as created_at,
-    (records->>'direction')::VARCHAR as direction, (records->>'_id')::VARCHAR as message_id,
-    (records->>'macro')::VARCHAR as macro, (records->>'match')::VARCHAR as match,
+    (records->'direction')::VARCHAR as direction,
+    (records->'_id')::VARCHAR as message_id,
+    (records->'macro')::VARCHAR as macro,
+    (records->'match')::VARCHAR as match,
     to_timestamp((((records->'metadata'->'delivery'->'deliveredAt'->>'$date')::BIGINT) / 1000)::DOUBLE PRECISION) as delivered_at,
     (records->'metadata'->'delivery'->>'totalSegments')::INT as total_segments,
-    (records->>'platformMessageId')::VARCHAR as platform_message_id, (records->>'template')::VARCHAR as template,
-    records->>'text' as text, (records->>'topic')::VARCHAR as topic, (records->>'userId')::VARCHAR as user_id
+    (records->'platformMessageId')::VARCHAR as platform_message_id,
+    (records->'template')::VARCHAR as template,
+    records->'text' as text, (records->'topic')::VARCHAR as topic,
+    (records->'userId')::VARCHAR as user_id
 FROM gambit_conversations.messages_json);
 
 CREATE INDEX platformmsgi on gambit_conversations.messages_flattened(platform_message_id);
-CREATE INDEX useridi on gambit_conversations.messages_flattened(user_id);
+CREATE INDEX usermidi on gambit_conversations.messages_flattened(user_id);
 
 GRANT SELECT on gambit_conversations.messages_flattened TO looker;
 GRANT SELECT on gambit_conversations.messages_flattened to dsanalyst;

--- a/data/sql/derived-tables/gambit_messages.sql
+++ b/data/sql/derived-tables/gambit_messages.sql
@@ -1,5 +1,5 @@
-DROP MATERIALIZED VIEW IF EXISTS gambit_conversations.messages CASCADE;
-CREATE MATERIALIZED VIEW gambit_conversations.messages AS
+DROP MATERIALIZED VIEW IF EXISTS gambit_conversations.messages_flattened CASCADE;
+CREATE MATERIALIZED VIEW gambit_conversations.messages_flattened AS
 (SELECT
     (records->>'agentId')::VARCHAR as agent_id,
     ((records->'attachments')::JSONB->0->>'url')::VARCHAR as attachment_url,
@@ -15,8 +15,8 @@ CREATE MATERIALIZED VIEW gambit_conversations.messages AS
     records->>'text' as text, (records->>'topic')::VARCHAR as topic, (records->>'userId')::VARCHAR as user_id
 FROM gambit_conversations.messages_json);
 
-CREATE INDEX platformmsgi on gambit_conversations.messages(platform_message_id);
-CREATE INDEX useridi on gambit_conversations.messages(user_id);
+CREATE INDEX platformmsgi on gambit_conversations.messages_flattened(platform_message_id);
+CREATE INDEX useridi on gambit_conversations.messages_flattened(user_id);
 
-GRANT SELECT on gambit_conversations.messages TO looker;
-GRANT SELECT on gambit_conversations.messages to dsanalyst;
+GRANT SELECT on gambit_conversations.messages_flattened TO looker;
+GRANT SELECT on gambit_conversations.messages_flattened to dsanalyst;

--- a/quasar/gambit_conversations.py
+++ b/quasar/gambit_conversations.py
@@ -7,7 +7,7 @@ def recreate_gambit_conversations():
 
 def refresh_gambit_conversations():
     refresh_materialized_view("gambit_conversations.conversations_json")
-    refresh_materialized_view("gambit_conversations.conversations")
+    refresh_materialized_view("gambit_conversations.conversations_flattened")
 
 
 def recreate_gambit_messages():
@@ -16,7 +16,7 @@ def recreate_gambit_messages():
 
 def refresh_gambit_messages():
     refresh_materialized_view("gambit_conversations.messages_json")
-    refresh_materialized_view("gambit_conversations.messages")
+    refresh_materialized_view("gambit_conversations.messages_flattened")
 
 
 def recreate_gambit_full():


### PR DESCRIPTION
#### What's this PR do?
* Updated table references in `gambit_conversations` that we've extrapolated out to relational format to have `_flattened` appended to them, since DMS table renaming has caused us issues.

#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/gambit-convo-fix?expand=1#diff-3093009998c9784257738b2d8478c353
#### How should this be manually tested?
Ran in staging.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/159699166

