### PR TITLE
Adding error handling for missing key in CIO msgs

### DIFF
--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -176,9 +176,8 @@ class CioQueue(QuasarQueue):
                 self._add_email_click_event(data)
             else event_type in email_event:
                 self._add_email_event(data)
-
-        exception KeyError:
-            logerr("This is bad")
+        exception KeyError, e:
+            logerr("C.IO message missing {}".format(e))
         exception:
             logerr("Something went wrong with C.IO consumer!")
             sys.exit(1)

--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -174,8 +174,8 @@ class CioQueue(QuasarQueue):
                 self._add_email_event(data)
             else:
                 pass
-        exception KeyError as e:
+        except KeyError as e:
             logerr("C.IO message missing {}".format(e))
-        exception:
+        except:
             logerr("Something went wrong with C.IO consumer!")
             sys.exit(1)

--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -170,8 +170,10 @@ class CioQueue(QuasarQueue):
                 self._add_unsub_event(data)
             elif event_type == 'email_clicked':
                 self._add_email_click_event(data)
-            else event_type in email_event:
+            elif event_type in email_event:
                 self._add_email_event(data)
+            else:
+                pass
         exception KeyError, e:
             logerr("C.IO message missing {}".format(e))
         exception:

--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -56,6 +56,10 @@ class CioQueue(QuasarQueue):
         log(''.join(("Logged data from "
                      "C.IO event id {}.")).format(data['event_id']))
 
+    def log_message(self, event_id):
+        log(''.join(("Added customer event from "
+                     "C.IO event id {}.")).format(data['event_id']))
+
     # Save customer sub data and dates.
     def _add_sub_event(self, data):
         self.db.query_str(''.join(("INSERT INTO cio.customer_event "
@@ -71,8 +75,7 @@ class CioQueue(QuasarQueue):
                            data['data']['email_address'],
                            data['event_id'], data['timestamp'],
                            data['event_type']))
-        log(''.join(("Added customer event from "
-                     "C.IO event id {}.")).format(data['event_id']))
+        return data['event_id']
 
     # Save customer unsub data and dates.
     def _add_unsub_event(self, data):
@@ -165,20 +168,17 @@ class CioQueue(QuasarQueue):
         # Always capture atomic c.io event in raw format.
         self._log_event(data)
         try:
-          if event_type == 'customer_subscribed':
-              self._add_sub_event(data)
-          elif event_type == 'customer_unsubscribed':
-              self._add_unsub_event(data)
-          elif event_type == 'email_clicked':
-              self._add_email_click_event(data)
-          elif event_type in email_event:
-              self._add_email_event(data)
-        except KeyError, e:
-            logerr("C.IO message missing {}".format(e))
-        except:
+            if event_type == 'customer_subscribed':
+                self._add_sub_event(data)
+            elif event_type == 'customer_unsubscribed':
+                self._add_unsub_event(data)
+            elif event_type == 'email_clicked':
+                self._add_email_click_event(data)
+            else event_type in email_event:
+                self._add_email_event(data)
+
+        exception KeyError:
+            logerr("This is bad")
+        exception:
             logerr("Something went wrong with C.IO consumer!")
             sys.exit(1)
-
-
-
-

--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -56,10 +56,6 @@ class CioQueue(QuasarQueue):
         log(''.join(("Logged data from "
                      "C.IO event id {}.")).format(data['event_id']))
 
-    def log_message(self, event_id):
-        log(''.join(("Added customer event from "
-                     "C.IO event id {}.")).format(data['event_id']))
-
     # Save customer sub data and dates.
     def _add_sub_event(self, data):
         self.db.query_str(''.join(("INSERT INTO cio.customer_event "

--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -164,14 +164,21 @@ class CioQueue(QuasarQueue):
         }
         # Always capture atomic c.io event in raw format.
         self._log_event(data)
-        if event_type == 'customer_subscribed':
-            self._add_sub_event(data)
-        elif event_type == 'customer_unsubscribed':
-            self._add_unsub_event(data)
-        elif event_type == 'email_clicked':
-            self._add_email_click_event(data)
-        elif event_type in email_event:
-            self._add_email_event(data)
-        else:
+        try:
+          if event_type == 'customer_subscribed':
+              self._add_sub_event(data)
+          elif event_type == 'customer_unsubscribed':
+              self._add_unsub_event(data)
+          elif event_type == 'email_clicked':
+              self._add_email_click_event(data)
+          elif event_type in email_event:
+              self._add_email_event(data)
+        except KeyError, e:
+            logerr("C.IO message missing {}".format(e))
+        except:
             logerr("Something went wrong with C.IO consumer!")
             sys.exit(1)
+
+
+
+

--- a/quasar/quasar_queue.py
+++ b/quasar/quasar_queue.py
@@ -174,7 +174,7 @@ class CioQueue(QuasarQueue):
                 self._add_email_event(data)
             else:
                 pass
-        exception KeyError, e:
+        exception KeyError as e:
             logerr("C.IO message missing {}".format(e))
         exception:
             logerr("Something went wrong with C.IO consumer!")


### PR DESCRIPTION
#### What's this PR do?
When CIO messages are missing required keys it breaks the CIO consumer. This PR adds error handling so that the consumer can continue and we're notified that the error is specifically a KeyError.
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
