### PR TITLE
Pollcall text no rb

### DIFF
--- a/data/sql/derived-tables/campaign_activity.sql
+++ b/data/sql/derived-tables/campaign_activity.sql
@@ -101,13 +101,13 @@ CREATE MATERIALIZED VIEW public.campaign_activity AS
 	        b."action" AS post_action,
 	        CASE 
                 WHEN b.id IS NULL THEN NULL 
-	        	WHEN a.campaign_id IN ('822','8119','8129') 
+	        	WHEN a.campaign_id IN ('822','8119','8129','8195','8202','8180') 
 	        	  AND a.created_at >= '2018-05-01' 
 	        	  THEN 'voter-reg - ground'
 	        	ELSE CONCAT(b."type", ' - ', b."action") END AS post_class,
 	        CASE 
                 WHEN b.id IS NULL THEN NULL
-	        	WHEN (a.campaign_id IN ('822','8129') 
+	        	WHEN (a.campaign_id IN ('822','8129','8195','8202','8180') 
 	        	  AND a.created_at >= '2018-05-01' 
 	        	  AND b.status = 'accepted') 
 	        	  OR (a.campaign_id IN ('8119') AND b.status <> 'rejected') 

--- a/data/sql/derived-tables/campaign_activity.sql
+++ b/data/sql/derived-tables/campaign_activity.sql
@@ -99,18 +99,22 @@ CREATE MATERIALIZED VIEW public.campaign_activity AS
 	        a.campaign_run_id AS campaign_run_id,
 	        b."type" AS post_type,
 	        b."action" AS post_action,
-	        CASE WHEN b.id IS NULL THEN NULL 
-	        		 WHEN a.campaign_id IN ('822','8119','8129') 
-	        		 AND a.created_at >= '2018-05-01' 
-	        		 THEN 'voter-reg - ground'
-	        		 ELSE CONCAT(b."type", ' - ', b."action") END AS post_class,
-	        	CASE WHEN b.id IS NULL THEN NULL
-	        		 WHEN (a.campaign_id IN ('822','8129') 
-	        		 AND a.created_at >= '2018-05-01' 
-	        		 AND b.status = 'accepted') 
-	        		 OR (a.campaign_id IN ('8119') AND b.status <> 'rejected') 
-	        		 THEN b.quantity
-	        		 ELSE 1 END AS reportback_volume,
+	        CASE 
+                WHEN b.id IS NULL THEN NULL 
+	        	WHEN a.campaign_id IN ('822','8119','8129') 
+	        	  AND a.created_at >= '2018-05-01' 
+	        	  THEN 'voter-reg - ground'
+	        	ELSE CONCAT(b."type", ' - ', b."action") END AS post_class,
+	        CASE 
+                WHEN b.id IS NULL THEN NULL
+	        	WHEN (a.campaign_id IN ('822','8129') 
+	        	  AND a.created_at >= '2018-05-01' 
+	        	  AND b.status = 'accepted') 
+	        	  OR (a.campaign_id IN ('8119') AND b.status <> 'rejected') 
+	        	  THEN b.quantity
+                WHEN a.campaign_id = '8167' AND b."type" = 'text'
+                  THEN 0
+	        	ELSE 1 END AS reportback_volume,
 	        b.status AS post_status,
 	        a.why_participated AS why_participated,
 	        b.quantity AS quantity,


### PR DESCRIPTION
#### What's this PR do?
* Adds several new campaigns to the special on the ground voter registration reportback tallying logic.
* Sets Poll Call text posts reportback value to 0
 
#### Where should the reviewer start?
* campaign_acitivity.sql

#### How should this be manually tested?
* Run the select statement in the public.campaign_activity matview creation

#### Any background context you want to provide?
* On the ground voter registration drive reportbacks show up as photos in Rogue with their reportback weight in rogue.posts.quantity. For these types of posts, we override the post class and set reportback_volume equal to their quantity, but only when the reportback is approved

#### What are the relevant tickets?
https://trello.com/c/41UQSlMB/1351-data-request-remove-poll-call-text-submissions-as-a-reportback-for-reporting-purposes

#### Screenshots (if appropriate)
#### Questions:
