### PR TITLE
remove bad signups from mel

### DIFF
--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -40,6 +40,10 @@ FROM (
             ON sd.id = s_maxupt.id AND sd.updated_at = s_maxupt.updated_at
         ) s 
     WHERE s.deleted_at IS NULL
+    AND s.id NOT IN (SELECT c.signup_id AS id 
+    				FROM campaign_activity c 
+    				WHERE c.signup_source = 'importer-client' 
+    				AND c.signup_created_at > c.post_created_at)
     UNION ALL
     SELECT -- CAMPAIGN POSTS WITH CHANNEL
         DISTINCT p.northstar_id AS northstar_id,


### PR DESCRIPTION
#### What's this PR do?
* Changes the MEL to exclude errant signups created by facebook share ingestion
#### Where should the reviewer start?
* mel.sql
#### How should this be manually tested?
* run the select statement for the signups sectioni
#### Any background context you want to provide?
* When we imported fb shares into rogue, one thing we overlooked was that the share only had campaign id, making the run indeterminate. When we imported them, chompy attributed them to the latest run for each campaign. So for folks with a share on a campaign with multiple runs, there was no way to know which was the right run. Since chompy creates signups on the fly when needed, it created signups for the latest run and gave it the created date of the import date. The solution was to remove signups where the signup source is the importer client and the post date is earlier than the signup created date
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/160490716
#### Screenshots (if appropriate)
#### Questions:
