### PR TITLE
toss bad fb share signups and reportbacks

### DIFF
--- a/data/sql/derived-tables/campaign_activity.sql
+++ b/data/sql/derived-tables/campaign_activity.sql
@@ -95,8 +95,9 @@ CREATE MATERIALIZED VIEW public.campaign_activity AS
 	        a.northstar_id AS northstar_id,
 	        CASE 
 	        	WHEN a."source" = 'importer-client' 
-	        	AND b.created_at > a.created_at 
-	        THEN -1 ELSE a.id AS signup_id,
+	        	AND b."type" = 'share-social'
+	        	AND b.created_at < a.created_at 
+	        THEN -1 ELSE a.id END AS signup_id,
 	        b.id AS post_id,
 	        a.campaign_id AS campaign_id,
 	        a.campaign_run_id AS campaign_run_id,

--- a/data/sql/derived-tables/campaign_activity.sql
+++ b/data/sql/derived-tables/campaign_activity.sql
@@ -93,7 +93,10 @@ CREATE MATERIALIZED VIEW public.campaign_activity AS
     FROM 
 	    (SELECT  
 	        a.northstar_id AS northstar_id,
-	        a.id AS signup_id,
+	        CASE 
+	        	WHEN a."source" = 'importer-client' 
+	        	AND b.created_at > a.created_at 
+	        THEN -1 ELSE a.id AS signup_id,
 	        b.id AS post_id,
 	        a.campaign_id AS campaign_id,
 	        a.campaign_run_id AS campaign_run_id,
@@ -112,7 +115,9 @@ CREATE MATERIALIZED VIEW public.campaign_activity AS
 	        	  AND b.status = 'accepted') 
 	        	  OR (a.campaign_id IN ('8119') AND b.status <> 'rejected') 
 	        	  THEN b.quantity
-                WHEN a.campaign_id = '8167' AND b."type" = 'text'
+                WHEN 
+                	(a.campaign_id = '8167' AND b."type" = 'text')
+                	OR (a.campaign_run_id IN ('8026','8021','8025','8103','8130','8168','8159','7928') AND b."type" = 'share-social')
                   THEN 0
 	        	ELSE 1 END AS reportback_volume,
 	        b.status AS post_status,


### PR DESCRIPTION
#### What's this PR do?
* Follow up to https://github.com/DoSomething/quasar/pull/629 to remove bad data from campaign activity
#### Where should the reviewer start?
* campaign_activity.sql
#### How should this be manually tested?
* Run each select statement 
#### Any background context you want to provide?
* fb share ingestion into rogue created bad signups and also created posts that aren't supposed to count towards reportbacks. This change scrubs signups (in the only way possible) from those ingested signups and sets the reportback volume to zero for the posts that have no reportback weight
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/160490716
#### Screenshots (if appropriate)
#### Questions:
