### PR TITLE
remove fb shares from mel

### DIFF
--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -162,22 +162,6 @@ FROM (
     AND 
         tv.nsid IS NOT NULL AND tv.nsid <> ''
     UNION ALL 
-    SELECT -- FACEBOOK SHARES FROM PHOENIX-NEXT
-        DISTINCT pe.northstar_id AS northstar_id,
-        to_timestamp(pe.ts /1000) AS "timestamp",
-        'facebook share completed' AS "action",
-        '9' AS action_id,
-        pe.event_source AS "source",
-        pe.event_id AS action_serial_id,
-        'web' AS "channel"
-    FROM 
-        public.phoenix_events pe
-    WHERE 
-        pe.event_name IN ('share action completed', 'facebook share posted')
-    AND pe.northstar_id IS NOT NULL
-    AND pe.northstar_id <> ''
-    AND to_timestamp(pe.ts /1000) <= '2018-08-07 18:00:00'
-    UNION ALL 
     SELECT DISTINCT -- SMS LINK CLICKS FROM BERTLY 
         b.northstar_id AS northstar_id,
         b.click_time AS "timestamp",


### PR DESCRIPTION
#### What's this PR do?
* Another piece of the facebook ingestion into rogue work. This PR removes fb shares from phoenix next from the member event log since all of these are now captured as rogue posts
#### Where should the reviewer start?
* mel.sql
#### How should this be manually tested?
* Run the SELECT within the MATVIEW create
#### Any background context you want to provide?
* Facebook shares are events that we wanted captured in rogue. Previously, these were being tracked in puck and were brought into reportback counts via the asterisk doc. They are now simply a type of post in rogue and so no longer need to be brought into the mel separately
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/160490716
#### Screenshots (if appropriate)
#### Questions:
