### PR TITLE
Creating a command to refresh in and outbound mat views only

### DIFF
--- a/quasar/gambit.py
+++ b/quasar/gambit.py
@@ -36,6 +36,12 @@ def refresh_gambit_messages():
     log("Refreshing public.gambit_messages_outbound derived table.")
     refresh_materialized_view("public.gambit_messages_outbound")
 
+def refresh_gambit_inbound_outbound():
+    log("Refreshing public.gambit_messages_inbound derived table.")
+    refresh_materialized_view("public.gambit_messages_inbound")
+    log("Refreshing public.gambit_messages_outbound derived table.")
+    refresh_materialized_view("public.gambit_messages_outbound")
+
 
 def create_gambit_full():
     # Only need messages since runs conversations as pre-req.

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
             'gambit_messages_create = quasar.gambit:create_gambit_messages',
             'gambit_messages_refresh = quasar.gambit:refresh_gambit_messages',
             'gambit_refresh_full = quasar.gambit:refresh_gambit_full',
+            'gambit_refresh_inbound_outbound = quasar.gambit:refresh_gambit_inbound_outbound'
             'gtm_retention_create = quasar.create_gtm_retention:main',
             'gtm_retention_refresh = quasar.refresh_gtm_retention:main',
             'mam_retention_create = quasar.create_mam_retention:main',


### PR DESCRIPTION
#### What's this PR do?
Jenkins jobs that refresh the inbound and outbound tables seem to be taking way too long. This PR isolates those commands so they can be tested separately to help debug the issue. 

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
https://jenkins.d12g.co/job/Gambit%20Messages%20Refresh/

#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
