### PR TITLE
Mel sms via gambit

### DIFF
--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -178,5 +178,4 @@ FROM (
     ); 
 CREATE INDEX ON public.member_event_log (event_id, northstar_id, "timestamp", action_serial_id);
 GRANT SELECT ON public.member_event_log TO looker;
-GRANT SELECT ON public.member_event_log TO jli;
-GRANT SELECT ON public.member_event_log TO shasan;
+GRANT SELECT ON public.member_event_log TO dsanalyst;

--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -120,16 +120,18 @@ FROM (
         GROUP BY u_create.id) u
     UNION ALL 
     SELECT -- LAST MESSAGED SMS 
-        DISTINCT u.id AS northstar_id,
-        u.last_messaged_at AS "timestamp",
+        DISTINCT g.user_id AS northstar_id,
+        g.created_at AS "timestamp",
         'messaged_gambit' AS "action", 
         '6' AS action_id,
         'SMS' AS "source",
-        '0' AS action_serial_id,
+        g.message_id AS action_serial_id,
         'sms' AS "channel"
     FROM
-        northstar.users u
-    WHERE u.last_messaged_at IS NOT NULL
+        public.gambit_messages_inbound g
+    WHERE 
+    	g.user_id IS NOT NULL
+    	AND g.macro <> 'subscriptionStatusStop' 
     UNION ALL 
         SELECT -- CLICKED EMAIL LINK 
             DISTINCT cio.customer_id AS northstar_id,


### PR DESCRIPTION
#### What's this PR do?
* THE FINAL STEP. This PR points the member event log to bring in gambit messages received from the gambit_messages_inbound derived table
* It also removes inbound messages that represent unsubscribes from the MEL so they can be removed from MAM counts
* It also removes discrete permission granting to analyst in favor of granting to the dsanalyst role
#### Where should the reviewer start?
* mel.sql
#### How should this be manually tested?
* Run the select statement within the MATVIEW create
#### Any background context you want to provide?
* This completes gambit integration work 
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/160109535
#### Screenshots (if appropriate)
#### Questions:
