### PR TITLE
Updating MEL to refresh concurrently.

### DIFF
--- a/quasar/mel.py
+++ b/quasar/mel.py
@@ -175,7 +175,7 @@ def main():
 
     db = Database()
 
-    db.query('REFRESH MATERIALIZED VIEW public.member_event_log')
+    db.query('REFRESH MATERIALIZED VIEW CONCURRENTLY public.member_event_log')
     db.disconnect()
 
     end_time = time.time()  # Record when script stopped running.


### PR DESCRIPTION
#### What's this PR do?
Update MEL materialized view to run with `concurrently` option that will allow it to not lock table on updates for other queries.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/concurrent-mel?expand=1#diff-610c9236fd4c690570f3f574ea6f3d41
#### How should this be manually tested?
Live, BAY-BEE!

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/161258184
