### PR TITLE
Remove voter reg mel

### DIFF
--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -145,24 +145,6 @@ FROM (
             cio.email_event cio
         WHERE 
             cio.event_type = 'email_clicked'
-    UNION ALL
-    SELECT -- VOTER REGISTRATIONS
-        DISTINCT tv.nsid AS northstar_id,
-        tv.created_at AS "timestamp",
-        'registered' AS "action",
-        '8' AS action_id,
-        tv.source_details AS "source",
-        '0' as action_serial_id,
-        (CASE WHEN tv.source = 'email' THEN 'email'
-        WHEN tv.source = 'web' OR tv.source = 'ads' THEN 'web'
-        WHEN tv.source = 'sms' THEN 'sms'
-        WHEN tv.source NOT IN ('email', 'sms', 'ads', 'web') THEN 'other' END) AS "channel"
-    FROM
-        public.turbovote_file tv
-    WHERE
-        tv.ds_vr_status IN ('register-form', 'confirmed', 'register-OVR')
-    AND 
-        tv.nsid IS NOT NULL AND tv.nsid <> ''
     UNION ALL 
     SELECT DISTINCT -- SMS LINK CLICKS FROM BERTLY 
         b.northstar_id AS northstar_id,

--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -76,7 +76,6 @@ FROM (
         ON pd.id = p_maxupt.id AND pd.updated_at = p_maxupt.updated_at
             ) p
     WHERE p.deleted_at IS NULL
-    AND p."type" IS DISTINCT FROM 'voter-reg'
     UNION ALL -- SITE ACCESS
     SELECT DISTINCT 
         u_access.id AS northstar_id,

--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -157,6 +157,6 @@ FROM (
     WHERE b.northstar_id IS NOT NULL
       ) AS a 
     ); 
-CREATE INDEX ON public.member_event_log (event_id, northstar_id, "timestamp", action_serial_id);
+CREATE UNIQUE INDEX ON public.member_event_log (event_id, northstar_id, action_id, action_serial_id, channel, "timestamp", "source");
 GRANT SELECT ON public.member_event_log TO looker;
 GRANT SELECT ON public.member_event_log TO dsanalyst;


### PR DESCRIPTION
#### What's this PR do?
* Removes voter registrations as a separate action in MEL since they will all now be posts in rogue

#### Where should the reviewer start?
* mel.sql

#### How should this be manually tested?
* Run the select portion of the statement

#### Any background context you want to provide?
* Rock the vote records are now being ingested into Rogue. Hence, we no longer need a separate table in quasar piping into the MEL to capture these action in our MAM counts. This allows us to simplify the MEL by removing this portion of the union and allowing voter reg post types into post actions

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/161324324

