### PR TITLE
Updating with unique indexes and concurrent mat view on campaign_activity

### DIFF
--- a/data/sql/derived-tables/campaign_activity.sql
+++ b/data/sql/derived-tables/campaign_activity.sql
@@ -22,7 +22,7 @@ CREATE MATERIALIZED VIEW public.signups AS
             ON sd.id = s_maxupt.id AND sd.updated_at = s_maxupt.updated_at
     )
     ; 
-CREATE INDEX signupsi ON public.signups (id, created_at); 
+CREATE UNIQUE INDEX signupsi ON public.signups (id, created_at); 
 
 DROP MATERIALIZED VIEW IF EXISTS public.latest_post CASCADE;
 CREATE MATERIALIZED VIEW public.latest_post AS
@@ -50,7 +50,7 @@ CREATE MATERIALIZED VIEW public.latest_post AS
             ON pd.id = p_maxupt.id AND pd.updated_at = p_maxupt.updated_at  
     )
     ;
-CREATE INDEX latest_posti ON public.latest_post (id, created_at); 
+CREATE UNIQUE INDEX latest_posti ON public.latest_post (id, created_at); 
 
 DROP MATERIALIZED VIEW IF EXISTS public.posts CASCADE;
 CREATE MATERIALIZED VIEW public.posts AS 
@@ -73,7 +73,7 @@ CREATE MATERIALIZED VIEW public.posts AS
     	) rtv ON rtv.post_id::bigint = pd.id::bigint
     )
 ;
-CREATE INDEX posti ON public.posts (id, created_at); 
+CREATE UNIQUE INDEX posti ON public.posts (id, created_at); 
 
 DROP MATERIALIZED VIEW IF EXISTS public.reported_back CASCADE;
 CREATE MATERIALIZED VIEW public.reported_back AS 
@@ -87,7 +87,7 @@ CREATE MATERIALIZED VIEW public.reported_back AS
         temp_posts.signup_id
     ) 
     ; 
-CREATE INDEX reported_backi ON public.reported_back (signup_id);
+CREATE UNIQUE INDEX reported_backi ON public.reported_back (signup_id);
 
 DROP MATERIALIZED VIEW IF EXISTS public.campaign_activity;
 CREATE MATERIALIZED VIEW public.campaign_activity AS 
@@ -164,7 +164,7 @@ CREATE MATERIALIZED VIEW public.campaign_activity AS
 	    ) ca
 	 )
     ;
-CREATE INDEX ON public.campaign_activity (northstar_id, signup_id, post_id, post_created_at, post_attribution_date);
+CREATE UNIQUE INDEX ON public.campaign_activity (northstar_id, signup_id, post_id, post_created_at, post_attribution_date);
 GRANT SELECT ON public.campaign_activity TO looker;
 GRANT SELECT ON public.campaign_activity TO jli;
 GRANT SELECT ON public.campaign_activity TO shasan;

--- a/quasar/refresh_campaign_activity.py
+++ b/quasar/refresh_campaign_activity.py
@@ -7,11 +7,11 @@ def main():
     start_time = time.time()
     """Keep track of start time of script."""
 
-    db.query("REFRESH MATERIALIZED VIEW public.signups")
-    db.query("REFRESH MATERIALIZED VIEW public.latest_post")
-    db.query("REFRESH MATERIALIZED VIEW public.posts")
-    db.query("REFRESH MATERIALIZED VIEW public.reported_back")
-    db.query("REFRESH MATERIALIZED VIEW public.campaign_activity")
+    db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.signups")
+    db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.latest_post")
+    db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.posts")
+    db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.reported_back")
+    db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.campaign_activity")
     db.disconnect()
 
     end_time = time.time()  # Record when script stopped running.


### PR DESCRIPTION
#### What's this PR do?
* Adds unique indexes to `campaign_activity` materialized view and all dependent tables.
* Adds `concurrent` argument to mat view refreshes to allow for read while refreshes happen.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/campaign_activity_unique?expand=1#diff-f20389da467ae54c8d51e844b1a0f66e
#### How should this be manually tested?
Doing. It. Live, from Heroku.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/161258184

