### PR TITLE
Update sql logic in bertly and mel

### DIFF
--- a/data/sql/derived-tables/bertly.sql
+++ b/data/sql/derived-tables/bertly.sql
@@ -21,8 +21,8 @@ CREATE MATERIALIZED VIEW public.bertly_clicks AS (
 			END) AS SOURCE,
 		CASE 
 			WHEN c.user_agent IS NULL THEN 'uncertain'
-			WHEN c.user_agent ILIKE '%%facebot%%' 
-				OR c.user_agent ILIKE '%%twitterbot%%' THEN 'preview'
+			WHEN c.user_agent ILIKE '%%facebot% twitterbot%'
+			     OR c.user_agent ILIKE '%X11; Ubuntu% i686%' THEN 'preview'
 			ELSE 'click' END AS interaction_type
 	FROM bertly.clicks c
 );

--- a/data/sql/derived-tables/bertly.sql
+++ b/data/sql/derived-tables/bertly.sql
@@ -21,7 +21,7 @@ CREATE MATERIALIZED VIEW public.bertly_clicks AS (
 			END) AS SOURCE,
 		CASE 
 			WHEN c.user_agent IS NULL THEN 'uncertain'
-			WHEN c.user_agent ILIKE '%%facebot %% twitterbot%%'
+			WHEN c.user_agent ILIKE '%%facebot twitterbot%%'
 			     OR c.user_agent ILIKE '%%X11; Ubuntu %% i686%%' THEN 'preview'
 			ELSE 'click' END AS interaction_type
 	FROM bertly.clicks c

--- a/data/sql/derived-tables/bertly.sql
+++ b/data/sql/derived-tables/bertly.sql
@@ -21,8 +21,8 @@ CREATE MATERIALIZED VIEW public.bertly_clicks AS (
 			END) AS SOURCE,
 		CASE 
 			WHEN c.user_agent IS NULL THEN 'uncertain'
-			WHEN c.user_agent ILIKE '%%facebot% twitterbot%'
-			     OR c.user_agent ILIKE '%X11; Ubuntu% i686%' THEN 'preview'
+			WHEN c.user_agent ILIKE '%%facebot %% twitterbot%%'
+			     OR c.user_agent ILIKE '%%X11; Ubuntu %% i686%%' THEN 'preview'
 			ELSE 'click' END AS interaction_type
 	FROM bertly.clicks c
 );

--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -148,7 +148,7 @@ FROM (
     SELECT DISTINCT -- SMS LINK CLICKS FROM BERTLY 
         b.northstar_id AS northstar_id,
         b.click_time AS "timestamp",
-        'bertly_link_click' AS "action",
+        CONCAT('bertly_link_', b.interaction_type) AS "action",
         '10' AS action_id,
         'bertly' AS "source",
         b.click_id AS action_serial_id,


### PR DESCRIPTION
#### What's this PR do?
It updates the bertly logic to capture Android and iOS previews in the interaction type field and appends whether the action is a click or preview in the mel logic. 
#### Where should the reviewer start?
Check bertly.sql followed by mel.sql.
#### How should this be manually tested?
#### Any background context you want to provide?
This is part of the effort to identify clicks vs. autogenerated previews vs. user-loaded previews. Given that there is no way to differentiate between the latter two using the user agent string, the decision was made to eventually ignore previews. This PR is the first step in that direction by labeling interactions as clicks/previews in bertly and then in mel.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/161419368
#### Screenshots (if appropriate)
#### Questions:
