### PR TITLE
Fix pattern matching for android preview user agent

### DIFF
--- a/data/sql/derived-tables/bertly.sql
+++ b/data/sql/derived-tables/bertly.sql
@@ -22,7 +22,7 @@ CREATE MATERIALIZED VIEW public.bertly_clicks AS (
 		CASE 
 			WHEN c.user_agent IS NULL THEN 'uncertain'
 			WHEN c.user_agent ILIKE '%%facebot twitterbot%%'
-			     OR c.user_agent ILIKE '%%X11; Ubuntu %% i686%%' THEN 'preview'
+			     OR c.user_agent ILIKE '%%X11; Ubuntu; Linux i686%%' THEN 'preview'
 			ELSE 'click' END AS interaction_type
 	FROM bertly.clicks c
 );


### PR DESCRIPTION
#### What's this PR do?
It fixes pattern matching for the android preview user agent to make sure they are actually captured as previews.
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
MEL numbers for preview vs. click looked oddly in favor of clicks. The reason is Android previews weren't being captured as 'bertly_link_preview'.
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
