### PR TITLE
Updating gambit messages recreate to just recreate messages.

### DIFF
--- a/quasar/gambit.py
+++ b/quasar/gambit.py
@@ -20,8 +20,8 @@ def refresh_gambit_conversations():
 
 
 def create_gambit_messages():
-    log("Creating Gambit Conversations derived tables, pre-req for Messages.")
-    run_sql_file('./data/sql/derived-tables/gambit_conversations.sql')
+    # Gambit conversations is a necessary precursor to exist
+    # before messages can be created.
     log("Creating Gambit Messages derived tables.")
     run_sql_file('./data/sql/derived-tables/gambit_messages.sql')
 


### PR DESCRIPTION
#### What's this PR do?
* Updates `gambit_messages_create` to only run `run_sql_file` once on the `gambit_messages.sql` file¸ not conversations then messages.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/gambit-messages-atomic?expand=1#diff-825bd03680e0c650867b952f7eb4919f

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/161619685
