### PR TITLE
Update MEL sql for posts and account creation

### DIFF
--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -74,6 +74,7 @@ FROM (
             GROUP BY ptemp.id) p_maxupt
         INNER JOIN rogue.posts pd
         ON pd.id = p_maxupt.id AND pd.updated_at = p_maxupt.updated_at
+	WHERE status in ('accepted', 'confirmed', 'register-OVR', 'register-form')
             ) p
     WHERE p.deleted_at IS NULL
     UNION ALL -- SITE ACCESS
@@ -116,6 +117,7 @@ FROM (
                 max(u_create."source") AS "source",
                 min(u_create.created_at) AS created_at
         FROM northstar.users u_create
+	WHERE u_create."source" IS DISTINCT FROM 'importer-client'
         GROUP BY u_create.id) u
     UNION ALL 
     SELECT -- LAST MESSAGED SMS 

--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -38,6 +38,9 @@ FROM (
             GROUP BY stemp.id) s_maxupt
         INNER JOIN rogue.signups sd
             ON sd.id = s_maxupt.id AND sd.updated_at = s_maxupt.updated_at
+        WHERE sd."source" IS DISTINCT FROM 'importer-client'
+        AND sd."source" IS DISTINCT FROM 'rock-the-vote'
+	AND sd."source" IS DISTINCT FROM 'turbovote'
         ) s 
     WHERE s.deleted_at IS NULL
     AND s.id NOT IN (SELECT c.signup_id AS id 
@@ -45,7 +48,7 @@ FROM (
     				WHERE c.signup_source = 'importer-client' 
     				AND c.signup_created_at > c.post_created_at)
     UNION ALL
-    SELECT -- CAMPAIGN POSTS WITH CHANNEL
+    SELECT -- CAMPAIGN POSTS WITH CHANNEL EXCLUDING RTV/TV
         DISTINCT p.northstar_id AS northstar_id,
         p.created_at AS "timestamp",
         'post' AS "action",
@@ -74,7 +77,9 @@ FROM (
             GROUP BY ptemp.id) p_maxupt
         INNER JOIN rogue.posts pd
         ON pd.id = p_maxupt.id AND pd.updated_at = p_maxupt.updated_at
-	WHERE status in ('accepted', 'confirmed', 'register-OVR', 'register-form')
+        WHERE pd.status IN ('accepted', 'confirmed', 'register-OVR', 'register-form')
+        AND pd."source" IS DISTINCT FROM 'rock-the-vote'
+        AND pd."source" IS DISTINCT FROM 'turbovote'
             ) p
     WHERE p.deleted_at IS NULL
     UNION ALL -- SITE ACCESS
@@ -157,6 +162,18 @@ FROM (
         b."source" AS "channel"
     FROM public.bertly_clicks b 
     WHERE b.northstar_id IS NOT NULL
+    UNION ALL
+    SELECT DISTINCT -- RTV/TV POSTS FROM CAMPAIGN ACTIVITY
+    	   ca.northstar_id AS northstar_id,
+	   ca.post_created_at AS "timestamp",
+	   'post' AS "action",
+	   '2' AS action_id,
+	   ca.post_source AS "source",
+	   ca.post_id::varchar AS action_serial_id,
+	   'web' AS channel
+    FROM public.campaign_activity ca
+    WHERE ca.post_source IN ('rock-the-vote', 'turbovote')
+    AND ca.post_status IN ('accepted', 'confirmed', 'register-OVR', 'register-form')
       ) AS a 
     ); 
 CREATE UNIQUE INDEX ON public.member_event_log (event_id, northstar_id, action_id, action_serial_id, channel, "timestamp", "source");


### PR DESCRIPTION
#### What's this PR do?
1) only includes posts with status: accepted, confirmed,
register-OVR, or register-form
2) removes accounts created by importer-client

#### How should this be manually tested?
Confirm counts align with expected counts.

#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
