### PR TITLE
Update Phoenix Web Analytics Mat Views with Unique Indexes

### DIFF
--- a/data/sql/derived-tables/create_puck_etl_json.sql
+++ b/data/sql/derived-tables/create_puck_etl_json.sql
@@ -37,7 +37,7 @@ CREATE MATERIALIZED VIEW puck.phoenix_utms AS (
 CREATE INDEX utm_index ON puck.phoenix_utms (session_id);
 
 CREATE MATERIALIZED VIEW public.phoenix_events AS (
-	SELECT 
+	SELECT DISTINCT
 		e.records #>> '{_id,$oid}' AS event_id,
 		e.records #>> '{meta,id}' AS puck_id,
 		to_timestamp((e.records #>> '{meta,timestamp}')::bigint/1000) AS event_datetime,
@@ -145,7 +145,7 @@ CREATE MATERIALIZED VIEW public.device_northstar_crosswalk AS
 		ON nsids.device_id = counts.device_id
 	);
 
-CREATE INDEX pe_indices ON phoenix_events (event_id, event_name, ts, event_datetime, northstar_id, session_id);
+CREATE UNIQUE INDEX pe_indices ON phoenix_events (event_id, event_name, ts, event_datetime, northstar_id, session_id);
 CREATE INDEX ps_indices ON phoenix_sessions (session_id, device_id, landing_ts, landing_datetime);
 CREATE INDEX dnc_indices ON device_northstar_crosswalk (northstar_id, device_id);
 

--- a/data/sql/derived-tables/create_puck_etl_json.sql
+++ b/data/sql/derived-tables/create_puck_etl_json.sql
@@ -146,7 +146,7 @@ CREATE MATERIALIZED VIEW public.device_northstar_crosswalk AS
 	);
 
 CREATE UNIQUE INDEX pe_indices ON phoenix_events (event_id, event_name, ts, event_datetime, northstar_id, session_id);
-CREATE INDEX ps_indices ON phoenix_sessions (session_id, device_id, landing_ts, landing_datetime);
+CREATE UNIQUE INDEX ps_indices ON phoenix_sessions (session_id, device_id, landing_ts, landing_datetime);
 CREATE INDEX dnc_indices ON device_northstar_crosswalk (northstar_id, device_id);
 
 GRANT SELECT ON public.phoenix_sessions TO public;

--- a/quasar/puck_events.py
+++ b/quasar/puck_events.py
@@ -18,7 +18,7 @@ def main():
     log("Refresh Puck UTMS mat view.")
     db.query('REFRESH MATERIALIZED VIEW puck.phoenix_utms')
     log('Refreshing public.phoenix_events.')
-    db.query('REFRESH MATERIALIZED VIEW public.phoenix_events')
+    db.query('REFRESH MATERIALIZED VIEW CONCURRENTLY public.phoenix_events')
     log('Refreshing public.phoenix_sessions.')
     db.query('REFRESH MATERIALIZED VIEW public.phoenix_sessions')
     log('Refreshing public.device_northstar_crosswalk.')

--- a/quasar/puck_events.py
+++ b/quasar/puck_events.py
@@ -20,7 +20,7 @@ def main():
     log('Refreshing public.phoenix_events.')
     db.query('REFRESH MATERIALIZED VIEW CONCURRENTLY public.phoenix_events')
     log('Refreshing public.phoenix_sessions.')
-    db.query('REFRESH MATERIALIZED VIEW public.phoenix_sessions')
+    db.query('REFRESH MATERIALIZED VIEW CONCURRENTLY public.phoenix_sessions')
     log('Refreshing public.device_northstar_crosswalk.')
     db.query('REFRESH MATERIALIZED VIEW public.device_northstar_crosswalk')
     db.disconnect()


### PR DESCRIPTION
#### What's this PR do?
* Updates `public.phoenix_events` query to provide unique values instead of having a myriad of dupe records. @sohaibhasan I'd def like your eyes on this to confirm the records look similar to current table. There's the `public.phoenix_events_test` mat view in Prod to diff/test against. Record counts align if you search for distinct records in current `public.phoenix_events` table.
* Updates `public.phoenix_sessions` to have unique index.
* Updates mat view refreshes for `public.phoenix_events` and `public.phoenix_sessions` to be concurrent.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/phoenix_events_unique?expand=1#diff-bdab02590558992256c341f898abd998
#### How should this be manually tested?
Manually tested SQL in Prod.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/161258184

