### PR TITLE
Mel query update (part 1)

### DIFF
--- a/data/sql/derived-tables/campaign_activity.sql
+++ b/data/sql/derived-tables/campaign_activity.sql
@@ -26,7 +26,8 @@ CREATE UNIQUE INDEX signupsi ON public.signups (id, created_at);
 
 DROP MATERIALIZED VIEW IF EXISTS public.latest_post CASCADE;
 CREATE MATERIALIZED VIEW public.latest_post AS
-    (SELECT 
+    (SELECT
+	pd.northstar_id as northstar_id,
         pd.id AS id,
         pd."type" AS "type",
         pd."action" AS "action",
@@ -55,8 +56,9 @@ CREATE UNIQUE INDEX latest_posti ON public.latest_post (id, created_at);
 DROP MATERIALIZED VIEW IF EXISTS public.posts CASCADE;
 CREATE MATERIALIZED VIEW public.posts AS 
     (SELECT 
-            pd.id AS id,
-            pd."type" AS "type",
+	    pd.northstar_id as northstar_id,
+	    pd.id AS id,
+	    pd."type" AS "type",
             pd."action" AS "action",
             pd.status AS status,
             pd.quantity AS quantity,

--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -162,7 +162,7 @@ FROM (
         b.click_id AS action_serial_id,
         b."source" AS "channel"
     FROM public.bertly_clicks b
-    JOIN public.users u
+    INNER JOIN public.users u
     ON b.northstar_id = u.northstar_id
     WHERE b.northstar_id IS NOT NULL
     UNION ALL

--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -151,6 +151,7 @@ FROM (
             cio.email_event cio
         WHERE 
             cio.event_type = 'email_clicked'
+	    AND cio.customer_id IS NOT NULL
     UNION ALL 
     SELECT DISTINCT -- SMS LINK CLICKS FROM BERTLY 
         b.northstar_id AS northstar_id,
@@ -160,7 +161,9 @@ FROM (
         'bertly' AS "source",
         b.click_id AS action_serial_id,
         b."source" AS "channel"
-    FROM public.bertly_clicks b 
+    FROM public.bertly_clicks b
+    JOIN public.users u
+    ON b.northstar_id = u.northstar_id
     WHERE b.northstar_id IS NOT NULL
     UNION ALL
     SELECT DISTINCT -- RTV/TV POSTS FROM CAMPAIGN ACTIVITY


### PR DESCRIPTION
#### What's this PR do?
This PR is the first of two that updates MEL/CA logic as part of the MEL audit. This first PR is related to various cleaning steps: 

- Pulls northstar id into public.posts.
- Moves the RTV date logic to the public.posts table.
- Removes null ids from cio and any bertly ids that are not in the public.users table from being added to the MEL.

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
This should have a negligible impact on MAMs, given that only the last of these steps results in dropping users. 

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/161757584
#### Screenshots (if appropriate)
#### Questions:
