### PR TITLE
Removes posts created by Ashes production monitor

### DIFF
--- a/data/sql/derived-tables/campaign_activity.sql
+++ b/data/sql/derived-tables/campaign_activity.sql
@@ -48,7 +48,9 @@ CREATE MATERIALIZED VIEW public.latest_post AS
          AND ptemp."source" IS DISTINCT FROM 'runscope-oauth'
         GROUP BY ptemp.id) p_maxupt
      INNER JOIN rogue.posts pd
-            ON pd.id = p_maxupt.id AND pd.updated_at = p_maxupt.updated_at  
+            ON pd.id = p_maxupt.id AND pd.updated_at = p_maxupt.updated_at
+     INNER JOIN public.signups s
+     	    ON pd.signup_id = s.id
     )
     ;
 CREATE UNIQUE INDEX latest_posti ON public.latest_post (id, created_at); 


### PR DESCRIPTION
#### What's this PR do?
Adds logic to the public.posts table that ensures all posts have a signup_id found in public.signups.

#### Where should the reviewer start?
campaign_activity.sql line 52

#### How should this be manually tested?
Did not have an impact on MAMs.

#### Any background context you want to provide?
https://dosomething.slack.com/archives/C0YGXUE01/p1542401924038900

#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
