### PR TITLE
remove bertly previews from MAM

### DIFF
--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -127,6 +127,7 @@ FROM (
     INNER JOIN public.users u
     ON b.northstar_id = u.northstar_id
     WHERE b.northstar_id IS NOT NULL
+    AND b.interaction_type IS DISTINCT FROM 'preview'
     ) AS a
    );
 CREATE UNIQUE INDEX ON public.member_event_log (event_id, northstar_id, action_id, action_serial_id, channel, "timestamp", "source");


### PR DESCRIPTION
#### What's this PR do?
* Removes bertly previews from MEL to remove them from MAM counts per the revised definition
#### Where should the reviewer start?
* mel.sql
#### How should this be manually tested?
* Did MAM counts update downwards?
#### Any background context you want to provide?
* Because we can't verify that link previews weren't autogenerated, we cannot consider them as action that make a member active
* Because of this, management decided these events should be removed
#### What are the relevant tickets?
* https://www.pivotaltracker.com/story/show/162425937
#### Screenshots (if appropriate)
#### Questions:
