### PR TITLE
Add SQL file to add signup/post campaign_id updates.

### DIFF
--- a/data/sql/misc/rogue-signup-posts-campaign-update.sql
+++ b/data/sql/misc/rogue-signup-posts-campaign-update.sql
@@ -1,0 +1,14 @@
+/* This SQL block is to address removal of campaign_run_id's
+   from DS systems, and updating them with campaign_id's */
+
+-- Update signups with new camaign_id based on campaign mapping table.
+UPDATE rogue.signups s
+SET campaign_id = c.id
+FROM rogue_prod.campaigns c
+WHERE s.campaign_run_id = c.campaign_run_id;
+
+-- Update posts with new campaign_id based on updated signups tbale.
+UPDATE rogue.posts t
+SET campaign_id = s.campaign_id
+FROM rogue.signups s
+WHERE t.signup_id = s.id;


### PR DESCRIPTION
#### What's this PR do?
- Updates Rogue signups and posts with new `campaign_id` as we deprecate `campaign_run_id`.

#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/rogue-signup-post-campaign-update?expand=1#diff-557f098283b4784ffa7bab38da1cc5f7
#### How should this be manually tested?
Tested against Quasar QA test tables.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/162313317

