### PR TITLE
Updating C.io consumer to be able to handle email_sent events.

### DIFF
--- a/quasar/cio_queue.py
+++ b/quasar/cio_queue.py
@@ -7,6 +7,7 @@ from .database import Database
 from .queue import QuasarQueue
 from .utils import log, logerr
 
+
 class CioQueue(QuasarQueue):
 
     def __init__(self):

--- a/quasar/cio_queue.py
+++ b/quasar/cio_queue.py
@@ -128,7 +128,8 @@ class CioQueue(QuasarQueue):
         email_event = {
             'email_converted',
             'email_opened',
-            'email_unsubscribed'
+            'email_unsubscribed',
+            'email_sent'
         }
         # Always capture atomic c.io event in raw format.
         self._log_event(data)


### PR DESCRIPTION
#### What's this PR do?
* Adds `email_sent` to list of `email_event` the c.io consumer can ingest email sends.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/email_sent_cio?expand=1#diff-9cfe7b6ae8cec24aa71005efd0fb7d6f
#### How should this be manually tested?
On Prod, Thursday.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/162914279
