### PR TITLE
Click campaign dms

### DIFF
--- a/quasar/campaign_info.py
+++ b/quasar/campaign_info.py
@@ -1,6 +1,9 @@
-from .database import Database
-from .sql_utils import run_sql_file
+import os
 import time
+
+from .database import Database
+from .refresh_dms import refresh_dms
+from .sql_utils import run_sql_file
 
 
 def create():
@@ -14,6 +17,7 @@ def main():
     start_time = time.time()
     """Keep track of start time of script."""
 
+    refresh_dms(os.environ.get('CAMPAIGNS_ARN'), 'Campaigns')
     db = Database()
 
     db.query('REFRESH MATERIALIZED VIEW rogue.campaign_info_all')

--- a/quasar/refresh_bertly.py
+++ b/quasar/refresh_bertly.py
@@ -1,7 +1,11 @@
+import os
+
 from .database import Database
+from .refresh_dms import refresh_dms
 
 
 def main():
+    refresh_dms(os.environ.get('BERTLY_ARN'), 'Bertly')
     db = Database()
     print('Refreshing Bertly Clicks materialized view.')
     db.query('REFRESH MATERIALIZED VIEW CONCURRENTLY public.bertly_clicks')

--- a/quasar/refresh_dms.py
+++ b/quasar/refresh_dms.py
@@ -49,3 +49,4 @@ def refresh_dms(arn, name=None):
     end_time = time.time()  # Record when script stopped running.
     duration = end_time - start_time  # Total duration in seconds.
     log("duration: {}".format(duration))
+    

--- a/quasar/refresh_dms.py
+++ b/quasar/refresh_dms.py
@@ -1,0 +1,51 @@
+import boto3
+import pydash
+import time
+from .utils import log
+
+dms = boto3.client('dms', region_name='us-east-1')
+
+
+def start_dms_refresh(arn):
+    """Refresh DMS task from given ARN."""
+    dms.start_replication_task(ReplicationTaskArn=arn,
+                               StartReplicationTaskType='reload-target')
+
+
+def check_refresh_status(arn):
+    """Report back metrics for DMS progress."""
+    task_progess = dms.describe_replication_tasks(Filters=[
+        {'Name': 'replication-task-arn',
+         'Values': [arn]}])
+    refresh_status = {}
+    refresh_status['status'] = pydash.get(task_progess,
+                                          'ReplicationTasks.0.Status')
+    refresh_status['reason'] = pydash.get(task_progess,
+                                          'ReplicationTasks.0.StopReason')
+    refresh_status['progress'] = pydash.get(task_progess,
+                                            'ReplicationTasks.0.ReplicationTaskStats.FullLoadProgressPercent')
+    return refresh_status
+
+
+def refresh_dms(arn, name=None):
+    start_time = time.time()
+    """Keep track of start time of script."""
+
+    # Kick off DMS refresh
+    log("Starting {} DMS refresh.".format(name))
+    start_dms_refresh(arn)
+    # Give job 10 seconds to start on AWS as a safety measure.
+    time.sleep(10)
+
+    status = check_refresh_status(arn)
+    while not (status['status'] == 'stopped' and
+               status['reason'] == 'Stop Reason FULL_LOAD_ONLY_FINISHED' and
+               status['progress'] == 100):
+        # SLeep between checks for 60 seconds, then try again.
+        log("{} DMS refresh still not done, waiting.".format(name))
+        time.sleep(60)
+        status = check_refresh_status(arn)
+
+    end_time = time.time()  # Record when script stopped running.
+    duration = end_time - start_time  # Total duration in seconds.
+    log("duration: {}".format(duration))

--- a/quasar/refresh_dms.py
+++ b/quasar/refresh_dms.py
@@ -49,4 +49,3 @@ def refresh_dms(arn, name=None):
     end_time = time.time()  # Record when script stopped running.
     duration = end_time - start_time  # Total duration in seconds.
     log("duration: {}".format(duration))
-    


### PR DESCRIPTION
#### What's this PR do?
* Adds utility function for performing DMS refreshes based on a provided ARN.
* Uses `refresh_dms` function for Bertly and Campaigns refreshes from Rogue to replace streaming functionality since DMS streaming is highly unreliable.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/click-campaign-dms?expand=1#diff-9c382ffd6e0a3f2ca35d125d75bb30c3
#### How should this be manually tested?
Tested refreshing the Bertly DMS refresh from my laptop, and it worked successfully.
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/163333861

