### PR TITLE
Adding raw event name when not in lookup table.

### DIFF
--- a/data/sql/derived-tables/create_puck_etl_json.sql
+++ b/data/sql/derived-tables/create_puck_etl_json.sql
@@ -54,7 +54,7 @@ CREATE MATERIALIZED VIEW public.phoenix_events AS (
 			THEN enames_old.old_name
 			ELSE enames_new.old_name END 
 			AS event_name,
-		COALESCE(enames_new.new_name, enames_old.new_name) AS new_event_name,
+		COALESCE(enames_new.new_name, enames_old.new_name, e.records #>> '{event,name}') AS new_event_name,
 		e.records #>> '{event,source}' AS event_source,
 		e.records #>> '{page,path}' AS "path",
 		e.records #>> '{page,host}' AS host,

--- a/data/sql/derived-tables/create_puck_etl_json.sql
+++ b/data/sql/derived-tables/create_puck_etl_json.sql
@@ -49,10 +49,11 @@ CREATE MATERIALIZED VIEW public.phoenix_events AS (
 		e.records #>> '{meta,id}' AS puck_id,
 		to_timestamp((e.records #>> '{meta,timestamp}')::bigint/1000) AS event_datetime,
 		(e.records #>> '{meta,timestamp}')::bigint AS ts,
-		CASE 
-			WHEN enames_old.old_name IS NOT NULL 
-			THEN enames_old.old_name
-			ELSE enames_new.old_name END 
+		COALESCE((CASE 
+				  WHEN enames_old.old_name IS NOT NULL 
+				  THEN enames_old.old_name
+				  ELSE enames_new.old_name END), 
+				  e.records #>> '{event,name}')
 			AS event_name,
 		COALESCE(enames_new.new_name, enames_old.new_name, e.records #>> '{event,name}') AS new_event_name,
 		e.records #>> '{event,source}' AS event_source,


### PR DESCRIPTION
#### What's this PR do?
* Updates `public.phoenix_events` table to have a name in `new_event_name`, regardless of whether it's in the `puck.event_lookup` table or not.

#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/puck-event?expand=1#diff-bdab02590558992256c341f898abd998
#### How should this be manually tested?
Manually created Mat View and ran successfully.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/163403099
