### PR TITLE
Casting working var to int, since Linux python runtime requires it.

### DIFF
--- a/quasar/cio_sent_backfill.py
+++ b/quasar/cio_sent_backfill.py
@@ -82,7 +82,7 @@ def main():
 		insert_bookmark(page['next'])
 	# While there is a page of results, continue processing.
 	while page:
-		with PoolExecutor(max_workers=os.getenv('POOL_SIZE')) as executor:
+		with PoolExecutor(max_workers=int(os.getenv('POOL_SIZE'))) as executor:
 			for _ in executor.map(insert_record, page['messages']):
 				pass
 		page = get_page(next_page=get_bookmark())

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="2019.1.23.0",
+    version="2019.1.24.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
* Cast thread workers `POOL_SIZE` to `int`, since is interpreted as `str` by Linux runtime.
