### PR TITLE
add device_id to phoenix_events

### DIFF
--- a/data/sql/derived-tables/create_puck_etl_json.sql
+++ b/data/sql/derived-tables/create_puck_etl_json.sql
@@ -74,7 +74,8 @@ CREATE MATERIALIZED VIEW public.phoenix_events AS (
 		e.records #> '{data,sourceData}' ->> 'text' AS source_data_text,
 		e.records #>> '{page,sessionId}' AS session_id,
 		e.records #>> '{browser,size}' AS browser_size,
-		e.records #>> '{user,northstarId}' AS northstar_id
+		e.records #>> '{user,northstarId}' AS northstar_id,
+		e.records #>> '{user,deviceId}' AS device_id
 	FROM puck.events_json e
 	LEFT JOIN puck.event_lookup enames_old ON e.records #>> '{event,name}' = enames_old.old_name
 	LEFT JOIN puck.event_lookup enames_new ON e.records #>> '{event,name}' = enames_new.new_name


### PR DESCRIPTION
#### What's this PR do?
Adds `device_id` to phoenix_events table.

#### Where should the reviewer start?
create_puck_etl_json.sql

#### Any background context you want to provide?
Having device id will facilitate conversion analytics that rely on that field to serve as the unique identifier.