### PR TITLE
Campaign Activity Disable Nested Loop

### DIFF
--- a/data/sql/derived-tables/campaign_activity.sql
+++ b/data/sql/derived-tables/campaign_activity.sql
@@ -33,6 +33,7 @@ CREATE UNIQUE INDEX ON public.signups (created_at, id);
 GRANT SELECT ON public.signups TO looker;
 GRANT SELECT ON public.signups TO dsanalyst;
 
+SET enable_nestloop = FALSE;
 DROP MATERIALIZED VIEW IF EXISTS public.latest_post CASCADE;
 CREATE MATERIALIZED VIEW public.latest_post AS
     (SELECT

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="2019.1.24.0",
+    version="2019.2.11.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
* Sets session disabling of `nested loops` which is what was massively slowing down the `public.latest_post` table creation we found out via the `EXPLAIN` part of the `campaign_activity` statement.
* We only disable this per session since other queries might be useful having this setting enabled.
* This will allow us to use Fivetran in Quasar Prod for `campaign_activity` tables.
* Version bump!
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/ft-posts-noloop?expand=1#diff-f20389da467ae54c8d51e844b1a0f66e
#### How should this be manually tested?
Tested this against a Heroku prod test instance that had Fivetran data propagating from Rogue Prod.
#### Any background context you want to provide?
We've swam to Hades across the River Styx without a life jacket, and finally emerged, haggard, on the other side challenging the SQL gods. 
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/163565944

