### PR TITLE
Email bounced backfill fix

### DIFF
--- a/data/sql/derived-tables/campaign_activity.sql
+++ b/data/sql/derived-tables/campaign_activity.sql
@@ -33,6 +33,7 @@ CREATE UNIQUE INDEX ON public.signups (created_at, id);
 GRANT SELECT ON public.signups TO looker;
 GRANT SELECT ON public.signups TO dsanalyst;
 
+SET enable_nestloop = FALSE;
 DROP MATERIALIZED VIEW IF EXISTS public.latest_post CASCADE;
 CREATE MATERIALIZED VIEW public.latest_post AS
     (SELECT

--- a/quasar/cio_bounced_backfill.py
+++ b/quasar/cio_bounced_backfill.py
@@ -42,9 +42,9 @@ def get_page(next_page=None):
 # Insert C.io email_bounced record atomically.
 def insert_record(message):
     query = text(''.join(("INSERT INTO cio.email_bounced_backfill(email_id, "
-                          "customer_id, email_address, template_id, event_id"
+                          "customer_id, email_address, template_id, subject, "
                           "timestamp) VALUES (:email_id, :customer_id, "
-                          ":email_address, :template_id, :event_id, "
+                          ":email_address, :template_id, :subject, "
                           "to_timestamp(:timestamp)) ON CONFLICT (email_id, "
                           " email_address, timestamp) DO NOTHING")))
     record = {
@@ -52,7 +52,7 @@ def insert_record(message):
         'customer_id': message['customer_id'],
         'email_address': message['recipient'],
         'template_id': message['msg_template_id'],
-        'event_id': message['event_id'],
+        'subject': message['subject'],
         'timestamp': message['metrics']['sent']
     }
     conn.execute(query, **record)

--- a/quasar/cio_queue.py
+++ b/quasar/cio_queue.py
@@ -144,15 +144,16 @@ class CioQueue(QuasarQueue):
     def _add_email_bounced_event(self, data):
         self.db.query_str(''.join(("INSERT INTO cio.email_bounced "
                                    "(email_id, customer_id, email_address, "
-                                   "template_id, event_id, "
+                                   "template_id, subject, event_id, "
                                    "timestamp) VALUES "
-                                   "(%s,%s,%s,%s,%s,to_timestamp(%s)) "
+                                   "(%s,%s,%s,%s,%s, %s, to_timestamp(%s)) "
                                    "ON CONFLICT (email_id, customer_id, "
                                    "timestamp) DO NOTHING")),
                           (data['data']['email_id'],
                            data['data']['customer_id'],
                            data['data']['email_address'],
                            data['data']['template_id'],
+                           data['data']['subject'],
                            data['event_id'], data['timestamp']))
         log(''.join(("Added email bounced event from "
                      "C.IO event id {}.")).format(data['event_id']))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="2019.1.24.0",
+    version="2019.2.12.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
I'm collecting the subject field to populate the subject in the email_bounced and email_bounced_backfill tables. I'm also removing the 'event_id' collection in the backfill since we don't get that from the API

#### Where should the reviewer start?
#### How should this be manually tested?
You can connect to QA since those tables are there and run the `cio_bounced_backfill` command
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/n/projects/2076969/stories/163632385
#### Screenshots (if appropriate)
#### Questions:
