### PR TITLE
Vote refresh

### DIFF
--- a/quasar/refresh_campaign_activity.py
+++ b/quasar/refresh_campaign_activity.py
@@ -9,6 +9,11 @@ def main():
 
     db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.signups")
     db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.latest_post")
+    db.query(''.join(("REFRESH MATERIALIZED VIEW CONCURRENTLY "
+                      "ft_dosomething_rogue.turbovote")))
+    db.query(''.join(("REFRESH MATERIALIZED VIEW CONCURRENTLY "
+                      "ft_dosomething_rogue.rock_the_vote")))
+    db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.signups")
     db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.posts")
     db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.reportbacks")
     db.disconnect()

--- a/quasar/refresh_campaign_activity.py
+++ b/quasar/refresh_campaign_activity.py
@@ -13,7 +13,6 @@ def main():
                       "ft_dosomething_rogue.turbovote")))
     db.query(''.join(("REFRESH MATERIALIZED VIEW CONCURRENTLY "
                       "ft_dosomething_rogue.rock_the_vote")))
-    db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.signups")
     db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.posts")
     db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.reportbacks")
     db.disconnect()


### PR DESCRIPTION
#### What's this PR do?
* Adds mat view refresh for Turbovote and RTV tables since we don't generate them on consumer side now, but derive them from Fivetran Rogue sync'd table.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/vote-refresh?expand=1#diff-a84354344be1123fdce649dcf03ee141R12

