### PR TITLE
Puck rogue cleanup

### DIFF
--- a/data/sql/derived-tables/campaign_info.sql
+++ b/data/sql/derived-tables/campaign_info.sql
@@ -1,5 +1,5 @@
-DROP MATERIALIZED VIEW IF EXISTS rogue.campaign_info_all CASCADE;
-CREATE MATERIALIZED VIEW IF NOT EXISTS rogue.campaign_info_all AS ( 
+DROP MATERIALIZED VIEW IF EXISTS ft_dosomething_rogue.campaign_info_all CASCADE;
+CREATE MATERIALIZED VIEW IF NOT EXISTS ft_dosomething_rogue.campaign_info_all AS ( 
     SELECT c.field_campaigns_target_id as campaign_node_id,
            n2.title as campaign_node_id_title,
            c.entity_id as campaign_run_id,
@@ -59,12 +59,14 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS public.campaign_info AS (
 		i.campaign_noun,
 		i.campaign_verb,
 		i.campaign_cta
-	FROM dosomething_rogue.campaigns c
-	LEFT JOIN rogue.campaign_info_all i ON i.campaign_run_id = c.campaign_run_id
+	FROM ft_dosomething_rogue.campaigns c
+	LEFT JOIN ft_dosomething_rogue.campaign_info_all i ON i.campaign_run_id = c.campaign_run_id
 	WHERE i.campaign_language = 'en' OR i.campaign_language IS NULL 
 );
+CREATE UNIQUE INDEX ON public.campaign_info (campaign_run_id, campaign_id);
 GRANT SELECT ON public.campaign_info TO dsanalyst;
 GRANT SELECT ON public.campaign_info TO looker;
+
 
 DROP MATERIALIZED VIEW IF EXISTS public.campaign_info_international CASCADE;
 CREATE MATERIALIZED VIEW IF NOT EXISTS public.campaign_info_international AS (
@@ -72,11 +74,9 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS public.campaign_info_international AS (
 		c.id AS campaign_id,
 		c.internal_title AS campaign_name,
 		i.*
-	FROM rogue.campaign_info_all i
-	LEFT JOIN dosomething_rogue.campaigns c ON i.campaign_run_id = c.campaign_run_id
+	FROM ft_dosomething_rogue.campaign_info_all i
+	LEFT JOIN ft_dosomething_rogue.campaigns c ON i.campaign_run_id = c.campaign_run_id
 	WHERE campaign_language IS DISTINCT FROM 'en'
 );
 GRANT SELECT ON public.campaign_info_international TO dsanalyst;
 GRANT SELECT ON public.campaign_info_international TO looker;
-
-CREATE UNIQUE INDEX ON public.campaign_info (campaign_run_id, campaign_id);

--- a/quasar/campaign_info.py
+++ b/quasar/campaign_info.py
@@ -19,7 +19,8 @@ def main():
 
     db = Database()
 
-    db.query('REFRESH MATERIALIZED VIEW ft_dosomething_rogue.campaign_info_all')
+    db.query(''.join(("REFRESH MATERIALIZED VIEW "
+                      "ft_dosomething_rogue.campaign_info_all")))
     db.query('REFRESH MATERIALIZED VIEW public.campaign_info')
     db.query('REFRESH MATERIALIZED VIEW public.campaign_info_international')
     db.disconnect()

--- a/quasar/campaign_info.py
+++ b/quasar/campaign_info.py
@@ -17,10 +17,9 @@ def main():
     start_time = time.time()
     """Keep track of start time of script."""
 
-    refresh_dms(os.environ.get('CAMPAIGNS_ARN'), 'Campaigns')
     db = Database()
 
-    db.query('REFRESH MATERIALIZED VIEW rogue.campaign_info_all')
+    db.query('REFRESH MATERIALIZED VIEW ft_dosomething_rogue.campaign_info_all')
     db.query('REFRESH MATERIALIZED VIEW public.campaign_info')
     db.query('REFRESH MATERIALIZED VIEW public.campaign_info_international')
     db.disconnect()

--- a/quasar/refresh_phoenix_events.py
+++ b/quasar/refresh_phoenix_events.py
@@ -9,8 +9,8 @@ def main():
 
     db.query("REFRESH MATERIALIZED VIEW public.path_campaign_lookup")
     db.query("REFRESH MATERIALIZED VIEW ft_puck_heroku_wzsf6b3z.phoenix_utms")
-    db.query("REFRESH MATERIALIZED VIEW public.phoenix_events")
-    db.query("REFRESH MATERIALIZED VIEW public.phoenix_sessions")
+    db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.phoenix_events")
+    db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.phoenix_sessions")
     db.query("REFRESH MATERIALIZED VIEW public.device_northstar_crosswalk")
     db.disconnect()
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="2019.3.4.0",
+    version="2019.3.5.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
* Updates `campaign_info` tables to use Fivetran Rogue propagation instead of old DMS job.
* Updates `phoenix_events` and `phoenix_sessions` to refresh concurrently since they're long-running, and non-current refreshes were blocking Looker view rebuilds.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/puck-rogue-cleanup?expand=1#diff-e265a6c36f85b94b24384760001a8f3e
#### How should this be manually tested?
* Queries are already tested, this is just reference updating. But will manually test after hours today.

