### PR TITLE
Gambit Unique Indexes for Concurrent Refreshes

### DIFF
--- a/data/sql/derived-tables/gambit_messages.sql
+++ b/data/sql/derived-tables/gambit_messages.sql
@@ -70,7 +70,7 @@ WHERE
 	g.direction = 'inbound'
 	AND g.user_id IS NULL));
 
-CREATE INDEX inbound_messages_i ON public.gambit_messages_inbound (message_id, created_at, user_id, conversation_id);
+CREATE UNIQUE INDEX ON public.gambit_messages_inbound (message_id, created_at, user_id, conversation_id);
 GRANT SELECT ON public.gambit_messages_inbound to looker;
 GRANT SELECT ON public.gambit_messages_inbound to dsanalyst;
 

--- a/data/sql/derived-tables/gambit_messages.sql
+++ b/data/sql/derived-tables/gambit_messages.sql
@@ -124,7 +124,7 @@ WHERE
 	g.direction <> 'inbound'
 	AND g.user_id IS NULL));
 
-CREATE INDEX outbound_messages_i ON public.gambit_messages_outbound (message_id, created_at, user_id, conversation_id);
+CREATE UNIQUE INDEX ON public.gambit_messages_outbound (message_id, created_at, user_id, conversation_id);
 GRANT SELECT ON public.gambit_messages_outbound to looker;
 GRANT SELECT ON public.gambit_messages_outbound to dsanalyst;
 

--- a/data/sql/derived-tables/gambit_messages.sql
+++ b/data/sql/derived-tables/gambit_messages.sql
@@ -22,8 +22,7 @@ CREATE MATERIALIZED VIEW ft_gambit_conversations_api.messages_flattened AS
  FROM ft_gambit_conversations_api.messages
 );
 
-CREATE INDEX platformmsgi ON ft_gambit_conversations_api.messages_flattened(platform_message_id);
-CREATE INDEX usermidi ON ft_gambit_conversations_api.messages_flattened(user_id);
+CREATE UNIQUE INDEX ON ft_gambit_conversations_api.messages_flattened (user_id, platform_message_id, delivered_at);
 
 GRANT SELECT ON ft_gambit_conversations_api.messages_flattened TO looker;
 GRANT SELECT ON ft_gambit_conversations_api.messages_flattened to dsanalyst;

--- a/quasar/gambit.py
+++ b/quasar/gambit.py
@@ -13,7 +13,7 @@ def refresh_gambit_messages():
     log("Refreshing ft_gambit_conversations_api.messages_flattened derived table.")
     refresh_materialized_view("CONCURRENTLY ft_gambit_conversations_api.messages_flattened")
     log("Refreshing public.gambit_messages_inbound derived table.")
-    refresh_materialized_view("public.gambit_messages_inbound")
+    refresh_materialized_view("CONCURRENTLY public.gambit_messages_inbound")
     log("Refreshing public.gambit_messages_outbound derived table.")
     refresh_materialized_view("public.gambit_messages_outbound")
 

--- a/quasar/gambit.py
+++ b/quasar/gambit.py
@@ -15,7 +15,7 @@ def refresh_gambit_messages():
     log("Refreshing public.gambit_messages_inbound derived table.")
     refresh_materialized_view("CONCURRENTLY public.gambit_messages_inbound")
     log("Refreshing public.gambit_messages_outbound derived table.")
-    refresh_materialized_view("public.gambit_messages_outbound")
+    refresh_materialized_view("CONCURRENTLY public.gambit_messages_outbound")
 
 
 def refresh_gambit_full():

--- a/quasar/gambit.py
+++ b/quasar/gambit.py
@@ -10,8 +10,11 @@ def create_gambit_messages():
 
 
 def refresh_gambit_messages():
-    log("Refreshing ft_gambit_conversations_api.messages_flattened derived table.")
-    refresh_materialized_view("CONCURRENTLY ft_gambit_conversations_api.messages_flattened")
+    log(''.join(("Refreshing ft_gambit_conversations_api.messages_flattened "
+                 "derived table.")))
+    refresh_materialized_view(''.join(("CONCURRENTLY "
+                                       "ft_gambit_conversations_api."
+                                       "messages_flattened")))
     log("Refreshing public.gambit_messages_inbound derived table.")
     refresh_materialized_view("CONCURRENTLY public.gambit_messages_inbound")
     log("Refreshing public.gambit_messages_outbound derived table.")

--- a/quasar/gambit.py
+++ b/quasar/gambit.py
@@ -11,7 +11,7 @@ def create_gambit_messages():
 
 def refresh_gambit_messages():
     log("Refreshing ft_gambit_conversations_api.messages_flattened derived table.")
-    refresh_materialized_view("ft_gambit_conversations_api.messages_flattened")
+    refresh_materialized_view("CONCURRENTLY ft_gambit_conversations_api.messages_flattened")
     log("Refreshing public.gambit_messages_inbound derived table.")
     refresh_materialized_view("public.gambit_messages_inbound")
     log("Refreshing public.gambit_messages_outbound derived table.")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="2019.3.5.0",
+    version="2019.3.8.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
* Adds unique indexes to `messages_flattened`, `gambit_messages_outbound`, and `gambit_messages_inbound` tables to allow materialized view refreshes to happen concurrently (so they're readable while refreshing and don't block queries).
* Updates mat view refresh statements for ^^ tables to have the `concurrently` argument.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/pull/730/files#diff-ee3906a65114da5425775eb8dc25047a
#### How should this be manually tested?
Tested indexes in QA with no collisions or issues.
