### PR TITLE
landing page bugfix

### DIFF
--- a/data/sql/derived-tables/phoenix_events.sql
+++ b/data/sql/derived-tables/phoenix_events.sql
@@ -127,13 +127,9 @@ CREATE MATERIALIZED VIEW public.phoenix_sessions AS (
 	LEFT JOIN (
 		SELECT e.page #>> '{sessionId}' AS session_id,
 		FIRST_VALUE(e.page #>> '{path}') OVER (
-		        PARTITION BY e.user #>> '{northstarId}', e.page #>> '{sessionId}'
-			ORDER BY (
-			(CASE WHEN
-				e.page #>> '{landingTimestamp}' = 'null'
-				THEN e.meta #>> '{timestamp}'
-				ELSE e.meta #>> '{landingTimestamp}' END
-			)::numeric)) AS landing_path
+		        PARTITION BY e.page #>> '{sessionId}'
+			ORDER BY (e.meta #>> '{timestamp}')::numeric)
+			AS landing_path
 		FROM ft_puck_heroku_wzsf6b3z.events e) e1
 	ON e1.session_id = e.page #>> '{sessionId}'
 	GROUP BY e.page #>> '{sessionId}'


### PR DESCRIPTION
#### What's this PR do?
Finds landing page by ordering by meta.timestamp field and removes unnecessary partition by northstar.

#### Where should the reviewer start?
phoenix_events.sql

#### How should this be manually tested?
Confirm that landing_page is the first page for a given session ID.
 
#### Any background context you want to provide?
This will allow number of sessions to match number of visits.
