### PR TITLE
add signup details to public signups table

### DIFF
--- a/data/sql/derived-tables/campaign_activity.sql
+++ b/data/sql/derived-tables/campaign_activity.sql
@@ -7,6 +7,7 @@ CREATE MATERIALIZED VIEW public.signups AS
         sd.campaign_run_id AS campaign_run_id,
         sd.why_participated AS why_participated,
         sd."source" AS "source",
+        sd.details,
 	CASE WHEN sd."source" = 'niche' THEN 'niche'
 	     WHEN sd."source" ilike '%%sms%%' THEN 'sms'
 	     WHEN sd."source" in ('rock-the-vote', 'turbovote') THEN 'voter-reg'


### PR DESCRIPTION
#### What's this PR do?
* Adds signup details to public signups table
#### Where should the reviewer start?
* campaign_activity
#### How should this be manually tested?
* run internal select
#### Any background context you want to provide?
* This is so we can tag a special cohort of sms signups, but could be useful for other things in the future too
* Stems from a partnership in the works allowing folks to text in a special keyword to our short code and recieve text actions regarding climate change
#### What are the relevant tickets?
* Ticketless
#### Screenshots (if appropriate)
#### Questions:
