### PR TITLE
Updating Phoenix Event tables to not refresh concurrently.

### DIFF
--- a/quasar/refresh_phoenix_events.py
+++ b/quasar/refresh_phoenix_events.py
@@ -1,22 +1,19 @@
-from .database import Database
-import time
+from .sa_database import Database
+from .utils import Duration
 
 
 def main():
     db = Database()
-    start_time = time.time()
-    """Keep track of start time of script."""
+    duration = Duration()
 
     db.query("REFRESH MATERIALIZED VIEW public.path_campaign_lookup")
     db.query("REFRESH MATERIALIZED VIEW ft_puck_heroku_wzsf6b3z.phoenix_utms")
-    db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.phoenix_events")
-    db.query("REFRESH MATERIALIZED VIEW CONCURRENTLY public.phoenix_sessions")
+    db.query("REFRESH MATERIALIZED VIEW public.phoenix_events")
+    db.query("REFRESH MATERIALIZED VIEW public.phoenix_sessions")
     db.query("REFRESH MATERIALIZED VIEW public.device_northstar_crosswalk")
     db.disconnect()
 
-    end_time = time.time()  # Record when script stopped running.
-    duration = end_time - start_time  # Total duration in seconds.
-    print('duration: ', duration)
+    duration.duration()
 
 
 if __name__ == "__main__":

--- a/quasar/utils.py
+++ b/quasar/utils.py
@@ -7,6 +7,7 @@ logging.getLogger().setLevel(logging.INFO)
 
 # DoSomething Helper Functions - Code Reused Across Lots of our ETL Scripts
 
+
 def strip_str(base_value):
     """Convert value to string and strips special characters.
 


### PR DESCRIPTION
#### What's this PR do?
* Updating Phoenix Event tables to not refresh concurrently.
* Updated to use SQL Alchemy database class.
* Uses the `Duration` class we have in utils instead of custom time code.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/phoenix-events-no-concurrency?expand=1#diff-25f97dc3ef09ccd4bc9f8768a3b11988
#### How should this be manually tested?
Local testing works, will test further in QA.

