### PR TITLE
Adding portable campaign_info_all refresh.

### DIFF
--- a/quasar/campaign_info.py
+++ b/quasar/campaign_info.py
@@ -44,8 +44,9 @@ def refresh():
     db = Database()
     duration = Duration()
 
-    db.query(''.join(("REFRESH MATERIALIZED VIEW "
-                      "ft_dosomething_rogue.campaign_info_all")))
+    # Setting statement for schema diffs of campaign_info_all
+    campaign_all = "REFRESH MATERIALIZED VIEW " + data['campaign_info_all']
+    db.query(campaign_all)
     db.query('REFRESH MATERIALIZED VIEW public.campaign_info')
     db.query('REFRESH MATERIALIZED VIEW public.campaign_info_international')
     db.disconnect()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="2019.3.25.0",
+    version="2019.3.25.1",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
* Updates `campaign_info_all` refresh part of campaign_info refresh to be portable among environments by relying on a variable.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/campaign-info-refresh?expand=1#diff-9c0c7201c8000c8539f08ed404e0c4b4

