### PR TITLE
Quick variable name hotfix for C.io queue.

### DIFF
--- a/quasar/cio_queue.py
+++ b/quasar/cio_queue.py
@@ -12,8 +12,8 @@ class CioQueue(QuasarQueue):
 
     def __init__(self):
         self.amqp_uri = os.environ.get('AMQP_URI')
-        self.cio_queue = os.environ.get('BLINK_QUEUE')
-        self.quasar_exchange = os.environ.get('BLINK_EXCHANGE')
+        self.blink_queue = os.environ.get('BLINK_QUEUE')
+        self.blink_exchange = os.environ.get('BLINK_EXCHANGE')
         super().__init__(self.amqp_uri, self.blink_queue,
                          self.blink_exchange)
         self.db = Database()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="2019.3.26.0",
+    version="2019.3.29.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
Fixes wrong var name for updated C.io class to use Blink vars instead of Quasar ones.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/cio-queue-hotfix?expand=1#diff-9cfe7b6ae8cec24aa71005efd0fb7d6fR15

