### PR TITLE
Removing event_log function for C.io events.

### DIFF
--- a/quasar/cio_queue.py
+++ b/quasar/cio_queue.py
@@ -18,14 +18,6 @@ class CioQueue(QuasarQueue):
                          self.blink_exchange)
         self.db = Database()
 
-    # Save entire c.io JSON blob to event_log table.
-    def _log_event(self, data):
-        record = {'event': json.dumps(data)}
-        query = ''.join(("INSERT INTO cio.event_log (event) VALUES :event"))
-        self.db.query_str(query, record)
-        log(''.join(("Logged data from "
-                     "C.IO event id {}.")).format(data['event_id']))
-
     # Save customer sub data and dates.
     def _add_sub_event(self, data):
         record = {
@@ -210,8 +202,6 @@ class CioQueue(QuasarQueue):
                 'email_opened',
                 'email_unsubscribed'
             }
-            # Always capture atomic c.io event in raw format.
-            self._log_event(data)
             try:
                 if event_type == 'customer_subscribed':
                     self._add_sub_event(data)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="2019.4.2.1",
+    version="2019.4.2.2",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
* Removes atomic logging of every C.io event for two reasons:
 1. We've never used the `cio.event_log` table.
 2. It's a large performance penalty to write out each event we get anyways.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/cio-remove-event-log?expand=1#diff-9cfe7b6ae8cec24aa71005efd0fb7d6f
#### How should this be manually tested?
In QA!

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/163568550

