### PR TITLE
Renamed _staging tables to _scratch for insert queries.

### DIFF
--- a/quasar/cio_queue.py
+++ b/quasar/cio_queue.py
@@ -28,7 +28,7 @@ class CioQueue(QuasarQueue):
             'timestamp': data['timestamp'],
             'event_type': data['event_type']
         }
-        query = ''.join(("INSERT INTO cio.customer_event_staging "
+        query = ''.join(("INSERT INTO cio.customer_event_scratch "
                          "(email_id, customer_id, email_address, "
                          "event_id, timestamp, "
                          "event_type) VALUES (:email_id,"
@@ -52,7 +52,7 @@ class CioQueue(QuasarQueue):
                 'timestamp': data['timestamp'],
                 'event_type': data['event_type']
             }
-            query = ''.join(("INSERT INTO cio.customer_event_staging "
+            query = ''.join(("INSERT INTO cio.customer_event_scratch "
                              "(email_id, customer_id,"
                              "email_address, template_id, event_id,"
                              "timestamp, event_type) "
@@ -72,7 +72,7 @@ class CioQueue(QuasarQueue):
                 'timestamp': data['timestamp'],
                 'event_type': data['event_type']
             }
-            query = ''.join(("INSERT INTO cio.customer_event_staging "
+            query = ''.join(("INSERT INTO cio.customer_event_scratch "
                              "(email_id, customer_id,"
                              "email_address, event_id, "
                              "timestamp, event_type) "
@@ -97,7 +97,7 @@ class CioQueue(QuasarQueue):
             'timestamp': data['timestamp'],
             'event_type': data['event_type']
         }
-        query = ''.join(("INSERT INTO cio.email_event_staging "
+        query = ''.join(("INSERT INTO cio.email_event_scratch "
                          "(email_id, customer_id, email_address, "
                          "template_id, event_id, timestamp, "
                          "event_type) VALUES "
@@ -122,7 +122,7 @@ class CioQueue(QuasarQueue):
             'event_id': data['event_id'],
             'timestamp': data['timestamp']
         }
-        query = ''.join(("INSERT INTO cio.email_sent_staging "
+        query = ''.join(("INSERT INTO cio.email_sent_scratch "
                          "(email_id, customer_id, email_address, "
                          "template_id, subject, event_id, "
                          "timestamp) VALUES "
@@ -149,7 +149,7 @@ class CioQueue(QuasarQueue):
             'timestamp': data['timestamp'],
             'event_type': data['event_type']
         }
-        query = ''.join(("INSERT INTO cio.email_event_staging "
+        query = ''.join(("INSERT INTO cio.email_event_scratch "
                          "(email_id, customer_id, email_address, "
                          "template_id, subject, href, link_id, "
                          "event_id, timestamp, "
@@ -175,7 +175,7 @@ class CioQueue(QuasarQueue):
             'event_id': data['event_id'],
             'timestamp': data['timestamp']
         }
-        query = ''.join(("INSERT INTO cio.email_bounced_staging "
+        query = ''.join(("INSERT INTO cio.email_bounced_scratch "
                          "(email_id, customer_id, email_address, "
                          "template_id, subject, event_id, "
                          "timestamp) VALUES "


### PR DESCRIPTION
#### What's this PR do?
* Forgot to rename insert statements for C.io scratch tables to be `_scratch`.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/cio-queue-table-name-fix?expand=1#diff-9cfe7b6ae8cec24aa71005efd0fb7d6fL31
#### How should this be manually tested?
QA.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/163568550

