### PR TITLE
Updating rogue ETL monitoring script to point to FT tables

### DIFF
--- a/quasar/etl_monitoring.py
+++ b/quasar/etl_monitoring.py
@@ -57,9 +57,9 @@ class ETLMonitoring:
             'raw_northstar':
                 'SELECT count(*) FROM northstar.users',
             'raw_rogue_signups':
-                'SELECT count(*) FROM rogue.signups',
+                'SELECT count(*) FROM ft_dosomething_rogue.signups',
             'raw_rogue_posts':
-                'SELECT count(*) FROM rogue.posts',
+                'SELECT count(*) FROM ft_dosomething_rogue.posts',
             'raw_puck_events':
                 'SELECT count(*) FROM ft_puck_heroku_wzsf6b3z.events',
             'raw_cio_emails':


### PR DESCRIPTION
#### What's this PR do?
The ETL monitoring script was failing for `rogue.signups` and `rogue.posts`. This PR updates the code to point to the new Fivetran Rogue tables

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
