### PR TITLE
Add table imports functions to include logic for duplicate records.

### DIFF
--- a/quasar/cio_import_scratch_records.py
+++ b/quasar/cio_import_scratch_records.py
@@ -5,15 +5,26 @@ db = Database()
 duration = Duration()
 
 
+def import_records_event(table):
+    # Import records from cio staging tables that are populated
+    # by the cio consumer into primary queried tables that have
+    # event_type based primary key.
+    scratch = table + '_scratch'
+    query = ''.join(("INSERT INTO {} SELECT * FROM {} "
+                     "ON CONFLICT (email_id, customer_id, timestamp, "
+                     "event_type) DO NOTHING"
+                     "")).format(table, scratch)
+    db.query(query)
+
 def import_records(table):
     # Import records from cio staging tables that are populated
     # by the cio consumer into primary queried tables.
     scratch = table + '_scratch'
-    query = ''.join(("INSERT INTO {} "
-                     "SELECT * FROM {}"
+    query = ''.join(("INSERT INTO {} SELECT * FROM {} "
+                     "ON CONFLICT (email_id, customer_id, timestamp) "
+                     "DO NOTHING"
                      "")).format(table, scratch)
     db.query(query)
-
 
 def truncate_scratch(table):
     # Truncate staging tables so consumer can resume updating
@@ -25,15 +36,19 @@ def truncate_scratch(table):
 
 def cio_import():
     # List of cio tables to process.
-    tables = ['cio.customer_event',
-              'cio.email_event',
-              'cio.email_sent',
-              'cio.email_bounced']
+    tables = ['cio.email_sent', 'cio.email_bounced']
+    event_tables = ['cio.customer_event', 'cio.email_event']
     for table in tables:
         log("Importing records for table {}.".format(table))
         import_records(table)
         scratch = table + '_scratch'
         log("Truncating table {}.".format(scratch))
         truncate_scratch(table)
+    for table in event_tables:
+        log("Importing records for table {}.".format(table))
+        import_records_event(table)
+        scratch = table + '_scratch'
+        log("Truncating table {}.".format(scratch))
+        truncate_scratch(table)    
     db.disconnect()
     duration.duration()

--- a/quasar/cio_import_scratch_records.py
+++ b/quasar/cio_import_scratch_records.py
@@ -16,6 +16,7 @@ def import_records_event(table):
                      "")).format(table, scratch)
     db.query(query)
 
+
 def import_records(table):
     # Import records from cio staging tables that are populated
     # by the cio consumer into primary queried tables.
@@ -25,6 +26,7 @@ def import_records(table):
                      "DO NOTHING"
                      "")).format(table, scratch)
     db.query(query)
+
 
 def truncate_scratch(table):
     # Truncate staging tables so consumer can resume updating
@@ -49,6 +51,6 @@ def cio_import():
         import_records_event(table)
         scratch = table + '_scratch'
         log("Truncating table {}.".format(scratch))
-        truncate_scratch(table)    
+        truncate_scratch(table)
     db.disconnect()
     duration.duration()


### PR DESCRIPTION
#### What's this PR do?
* Fixes a bug in `cio_import` that would cause errors on duplicate records. Solves this issue by breaking down `table_import` into two functions that on duplicates ignores new records.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/cio-import-conflict?expand=1#diff-027bf8d24c35cf0451f75c4775e84259R8
#### How should this be manually tested?
QA!
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/164869907

