### PR TITLE
Update posts for phone calls and to add location

### DIFF
--- a/data/sql/derived-tables/campaign_activity.sql
+++ b/data/sql/derived-tables/campaign_activity.sql
@@ -98,6 +98,7 @@ CREATE MATERIALIZED VIEW public.posts AS
 	    	 THEN 1
 	    	 ELSE NULL END AS is_accepted,
 	    pd.action_id,
+	    pd.location,
 	    a.reportback AS is_reportback,
 	    a.civic_action,
 	    a.scholarship_entry
@@ -142,6 +143,7 @@ CREATE MATERIALIZED VIEW public.reportbacks AS
 	pd.reportback_volume,
 	pd.civic_action,
 	pd.scholarship_entry,
+	pd.location,
 	CASE WHEN (pd.post_class ilike '%%vote%%' AND pd.status = 'confirmed')
 	     THEN 'self-reported registrations'
 	     WHEN (pd.post_class ilike '%%vote%%' AND pd.status <> 'confirmed')


### PR DESCRIPTION
#### What's this PR do?
- Uses call time for post `created at` for phone calls (rather than time of post creation)
- Adds phone-calls `post bucket` type
- Pulls in location data for posts

#### Where should the reviewer start?
campaign_activity.sql

#### How should this be manually tested?
verified logic in QA 

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/165097325

