### PR TITLE
Hotfix for missing ft_rogue_actions variable.

### DIFF
--- a/quasar/create_campaign_activity.py
+++ b/quasar/create_campaign_activity.py
@@ -7,6 +7,7 @@ data = {
     'ft_rogue_posts': os.getenv('FT_ROGUE_POSTS'),
     'ft_rogue_turbovote': os.getenv('FT_ROGUE_TURBOVOTE'),
     'ft_rogue_rtv': os.getenv('FT_ROGUE_RTV'),
+    'ft_rogue_actions': os.getenv('FT_ROGUE_ACTIONS')
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="2019.4.9.2",
+    version="2019.4.9.3",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
Adds missing required variable for campaign activity to run successfully.

