### PR TITLE
Adding a needed space to MEL so run_sql_file doesn't munge query.

### DIFF
--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -18,7 +18,7 @@ CREATE MATERIALIZED VIEW public.member_event_log AS
     	OVER 
     	(PARTITION BY a.northstar_id, date_trunc('month', a."timestamp")) 
     	AS first_action_month
-FROM ( 
+  FROM ( 
     SELECT -- CAMPAIGN SIGNUP WITH CHANNEL
         DISTINCT s.northstar_id AS northstar_id,
         s.created_at AS "timestamp",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="2019.4.9.2",
+    version="2019.4.10.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
* When MEL `run_sql_file` runs, there was no space at the beginning of the noted `FROM` line which would result in an error, since we remove new lines as part of the string processing from files. This space should fix the query.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/mel-space-fix?expand=1#diff-5a95f0bc110afa2ae9d7cfd377837ebfL21
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/164784638

