### PR TITLE
Updating email subscription status on conflict

### DIFF
--- a/quasar/northstar_to_user_table.py
+++ b/quasar/northstar_to_user_table.py
@@ -87,7 +87,7 @@ def _save_user(user):
                      ":last_authenticated_at,:last_messaged_at,"
                      ":updated_at,:created_at,:email_subscription_status) "
                      "ON CONFLICT (id, created_at, updated_at) "
-                     "DO NOTHING"))
+                     "DO UPDATE SET email_subscription_status = :email_subscription_status"))
     db.query_str(query, record)
 
 

--- a/quasar/northstar_to_user_table.py
+++ b/quasar/northstar_to_user_table.py
@@ -87,7 +87,9 @@ def _save_user(user):
                      ":last_authenticated_at,:last_messaged_at,"
                      ":updated_at,:created_at,:email_subscription_status) "
                      "ON CONFLICT (id, created_at, updated_at) "
-                     "DO UPDATE SET email_subscription_status = :email_subscription_status"))
+                     "DO UPDATE SET "
+                     "email_subscription_status = :email_subscription_status"
+                     ""))
     db.query_str(query, record)
 
 


### PR DESCRIPTION
#### What's this PR do?
The cio_status was not being updated when the record had a conflict on `id, created_at, updated_at`. This PR will update the email subscription status even when there's a conflict on those three fields. 

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/n/projects/2076969/stories/163568550
#### Screenshots (if appropriate)
#### Questions:
Is it better to just add `email_subscription_status` to the conflict statement?
