### PR TITLE
update MEL indexes to improve query performance

### DIFF
--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -151,6 +151,7 @@ CREATE MATERIALIZED VIEW public.member_event_log AS
     ) AS a
  LEFT JOIN public.users u ON u.northstar_id = a.northstar_id
    );
-CREATE UNIQUE INDEX ON public.member_event_log (event_id, northstar_id, action_id, action_serial_id, channel, "timestamp", "source");
+CREATE UNIQUE INDEX ON public.member_event_log ("timestamp", northstar_id, event_id);
+CREATE INDEX ON public.member_event_log (northstar_id, "timestamp");
 GRANT SELECT ON public.member_event_log TO looker;
 GRANT SELECT ON public.member_event_log TO dsanalyst;


### PR DESCRIPTION
#### What's this PR do?
This PR creates two indexes to determine if query performance is improved: 
1) A unique index on `timestamp`, `northstar_id`, `event_id` which allows for more efficient time-based querying. 
2) An index on `timestamp`, `northstar_id` that allows for more efficient window operations when querying for time between events. Testing on a subset of the member event log improved performance from 30 minutes and counting to < 1 second.

#### Where should the reviewer start?
mel.sql

#### How should this be manually tested?
See above.
