### PR TITLE
Restoring removed MEL indexes for performance optimization for user activity

### DIFF
--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -1,4 +1,4 @@
- DROP MATERIALIZED VIEW IF EXISTS public.member_event_log CASCADE; 
+DROP MATERIALIZED VIEW IF EXISTS public.member_event_log CASCADE; 
 CREATE MATERIALIZED VIEW public.member_event_log AS 
 (SELECT
     MD5(concat(a.northstar_id, a."timestamp", a.action_id, a.action_serial_id)) AS event_id,

--- a/data/sql/derived-tables/mel.sql
+++ b/data/sql/derived-tables/mel.sql
@@ -1,4 +1,4 @@
-DROP MATERIALIZED VIEW IF EXISTS public.member_event_log CASCADE; 
+ DROP MATERIALIZED VIEW IF EXISTS public.member_event_log CASCADE; 
 CREATE MATERIALIZED VIEW public.member_event_log AS 
 (SELECT
     MD5(concat(a.northstar_id, a."timestamp", a.action_id, a.action_serial_id)) AS event_id,
@@ -151,6 +151,7 @@ CREATE MATERIALIZED VIEW public.member_event_log AS
     ) AS a
  LEFT JOIN public.users u ON u.northstar_id = a.northstar_id
    );
-CREATE UNIQUE INDEX ON public.member_event_log (event_id, northstar_id, action_id, action_serial_id, channel, "timestamp", "source");
+CREATE UNIQUE INDEX ON public.member_event_log ("timestamp", northstar_id, event_id);
+CREATE INDEX ON public.member_event_log (northstar_id, "timestamp");
 GRANT SELECT ON public.member_event_log TO looker;
 GRANT SELECT ON public.member_event_log TO dsanalyst;

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="quasar",
-    version="2019.6.5.1",
+    version="2019.6.10.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
* We accidentally removed the indexes on MEL required for performant `user_activity` mat view generation from [PR] (https://github.com/DoSomething/quasar/commit/c52ab2f0df08e547b51fbfffdee0d9b5a642d252). This PR restores them.
#### Where should the reviewer start?
https://github.com/DoSomething/quasar/compare/mel-index-update?expand=1#diff-5a95f0bc110afa2ae9d7cfd377837ebfR154

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/166470581

