### PR TITLE
adding the first event_id to the sessions table

### DIFF
--- a/data/sql/derived-tables/snowplow_events.sql
+++ b/data/sql/derived-tables/snowplow_events.sql
@@ -126,6 +126,8 @@ CREATE TABLE public.snowplow_sessions AS (
 	    session_id,
 	    first_value("path") OVER (PARTITION BY session_id ORDER BY event_datetime 
 		ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS landing_page,
+	    first_value(event_id) OVER (PARTITION BY session_id ORDER BY event_datetime 
+		ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS event_id,
 	    last_value("path") OVER (PARTITION BY session_id ORDER BY event_datetime 
 		ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS exit_page
 	FROM snowplow_phoenix_events
@@ -141,6 +143,7 @@ CREATE TABLE public.snowplow_sessions AS (
     )
     SELECT
 	s.session_id,
+	p.event_id,
 	s.device_id,
 	s.landing_datetime,
 	s.ending_datetime,

--- a/data/sql/derived-tables/snowplow_events_refresh.sql
+++ b/data/sql/derived-tables/snowplow_events_refresh.sql
@@ -146,6 +146,8 @@ CREATE TABLE public.snowplow_sessions_stage AS (
         session_id,
         first_value("path") OVER (PARTITION BY session_id ORDER BY event_datetime 
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS landing_page,
+        first_value(event_id) OVER (PARTITION BY session_id ORDER BY event_datetime 
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS event_id,
         last_value("path") OVER (PARTITION BY session_id ORDER BY event_datetime 
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS exit_page
     FROM snowplow_phoenix_events
@@ -161,6 +163,7 @@ CREATE TABLE public.snowplow_sessions_stage AS (
     )
     SELECT
     s.session_id,
+    p.event_id,
     s.device_id,
     s.landing_datetime,
     s.ending_datetime,


### PR DESCRIPTION
#### What's this PR do?
It adds the `event_id` of the first event in each session. This will allow us to more accurately join the events and sessions table on `session_id` and `event_id`.

#### Where should the reviewer start?
snowplow_events.sql and snowplow_events_refresh.sql 

#### How should this be manually tested?
Run locally and confirm that the path and event_id of the first event in phoenix_events aligns with the landing_page and event_id in phoenix_sessions for a given session

