### PR TITLE
feature: Expose carrier_delivered_at and carrier_failure_code in gambit_messages_outbound

### DIFF
--- a/data/sql/derived-tables/gambit_messages.sql
+++ b/data/sql/derived-tables/gambit_messages.sql
@@ -12,11 +12,8 @@ CREATE MATERIALIZED VIEW :ft_gambit_messages_flattened AS
     _id AS message_id,
     macro AS macro,
     match AS match,
-    metadata #>> '{delivery,queuedAt}' AS sent_at,
-		metadata #>> '{delivery,deliveredAt}' AS delivered_at,
-	  metadata #>> '{delivery,failedAt}' as failed_at,
-    metadata #>> '{delivery,failureData,code}' as failure_code,
-    (metadata #>> '{retryCount}')::INT AS retry_count,
+		metadata #>> '{delivery,deliveredAt}' AS carrier_delivered_at,
+    metadata #>> '{delivery,failureData,code}' as carrier_failure_code,
     (metadata #> '{delivery}' ->> 'totalSegments')::INT AS total_segments,
     platform_message_id as platform_message_id,
     template AS template,
@@ -54,11 +51,8 @@ CREATE MATERIALIZED VIEW public.gambit_messages_inbound AS
 	g.message_id,
 	g.macro,
 	g."match",
-	g.sent_at
-	g.delivered_at,
-	g.failed_at,
-	g.failure_code,
-  g.retry_count,
+	g.carrier_delivered_at,
+	g.carrier_failure_code,
 	g.total_segments,
 	g.platform_message_id,
 	g.template,
@@ -94,11 +88,8 @@ CREATE MATERIALIZED VIEW public.gambit_messages_outbound AS
 	f.message_id,
 	f.macro,
 	f."match",
-  f.sent_at,
-	f.delivered_at,
-	f.failed_at,
-	f.failure_code,
-  f.retry_count,
+	f.carrier_delivered_at,
+	f.carrier_failure_code,
 	f.platform_message_id,
 	f.template,
 	f.text,
@@ -119,11 +110,8 @@ CREATE MATERIALIZED VIEW public.gambit_messages_outbound AS
 	g.message_id,
 	g.macro,
 	g."match",
-  g.sent_at,
-	g.delivered_at,
-	g.failed_at,
-	g.failure_code,
-  g.retry_count,
+	g.carrier_delivered_at,
+	g.carrier_failure_code,
 	g.platform_message_id,
 	g.template,
 	g.text,
@@ -144,6 +132,6 @@ CREATE MATERIALIZED VIEW public.gambit_messages_outbound AS
 	AND g.user_id IS NULL));
 
 CREATE INDEX ON public.gambit_messages_outbound (message_id, created_at, user_id, conversation_id);
-CREATE INDEX deliverability ON public.gambit_messages_outbound (created_at, failure_code);
+CREATE INDEX deliverability ON public.gambit_messages_outbound (created_at, carrier_failure_code);
 GRANT SELECT ON public.gambit_messages_outbound to looker;
 GRANT SELECT ON public.gambit_messages_outbound to dsanalyst;

--- a/data/sql/derived-tables/gambit_messages.sql
+++ b/data/sql/derived-tables/gambit_messages.sql
@@ -16,7 +16,7 @@ CREATE MATERIALIZED VIEW :ft_gambit_messages_flattened AS
 		metadata #>> '{delivery,deliveredAt}' AS delivered_at,
 	  metadata #>> '{delivery,failedAt}' as failed_at,
     metadata #>> '{delivery,failureData,code}' as failure_code,
-    COALESCE(metadata #> '{retryCount}', 0) AS retry_count,
+    (metadata #>> '{retryCount}')::INT AS retry_count,
     (metadata #> '{delivery}' ->> 'totalSegments')::INT AS total_segments,
     platform_message_id as platform_message_id,
     template AS template,

--- a/data/sql/derived-tables/gambit_messages.sql
+++ b/data/sql/derived-tables/gambit_messages.sql
@@ -13,7 +13,7 @@ CREATE MATERIALIZED VIEW :ft_gambit_messages_flattened AS
     macro AS macro,
     match AS match,
     metadata #>> '{delivery,queuedAt}' AS delivered_at,
-		metadata #>> '{delivery,failedAt}' as failed_at,
+	  metadata #>> '{delivery,failedAt}' as failed_at,
     metadata #>> '{delivery,failureData,code}' as failure_code,
     (metadata #> '{delivery}' ->> 'totalSegments')::INT AS total_segments,
     platform_message_id as platform_message_id,

--- a/data/sql/derived-tables/gambit_messages.sql
+++ b/data/sql/derived-tables/gambit_messages.sql
@@ -12,7 +12,8 @@ CREATE MATERIALIZED VIEW :ft_gambit_messages_flattened AS
     _id AS message_id,
     macro AS macro,
     match AS match,
-    metadata #>> '{delivery,queuedAt}' AS delivered_at,
+    metadata #>> '{delivery,queuedAt}' AS sent_at,
+		metadata #>> '{delivery,deliveredAt}' AS delivered_at,
 	  metadata #>> '{delivery,failedAt}' as failed_at,
     metadata #>> '{delivery,failureData,code}' as failure_code,
     (metadata #> '{delivery}' ->> 'totalSegments')::INT AS total_segments,
@@ -52,7 +53,10 @@ CREATE MATERIALIZED VIEW public.gambit_messages_inbound AS
 	g.message_id,
 	g.macro,
 	g."match",
+	g.sent_at
 	g.delivered_at,
+	g.failed_at,
+	g.failure_code,
 	g.total_segments,
 	g.platform_message_id,
 	g.template,
@@ -88,6 +92,7 @@ CREATE MATERIALIZED VIEW public.gambit_messages_outbound AS
 	f.message_id,
 	f.macro,
 	f."match",
+  f.sent_at,
 	f.delivered_at,
 	f.failed_at,
 	f.failure_code,
@@ -111,6 +116,7 @@ CREATE MATERIALIZED VIEW public.gambit_messages_outbound AS
 	g.message_id,
 	g.macro,
 	g."match",
+  g.sent_at,
 	g.delivered_at,
 	g.failed_at,
 	g.failure_code,
@@ -133,6 +139,6 @@ CREATE MATERIALIZED VIEW public.gambit_messages_outbound AS
 	g.direction <> 'inbound'
 	AND g.user_id IS NULL));
 
-CREATE INDEX ON public.gambit_messages_outbound (message_id, created_at, delivered_at, user_id, conversation_id);
+CREATE INDEX ON public.gambit_messages_outbound (message_id, created_at, user_id, conversation_id);
 GRANT SELECT ON public.gambit_messages_outbound to looker;
 GRANT SELECT ON public.gambit_messages_outbound to dsanalyst;


### PR DESCRIPTION
#### What's this PR do?
- It adds the `carrier_delivered_at` and `carrier_failure_code` columns to the `gambit_messages_outbound` derived table.
