### PR TITLE
Newsletter table fixes

### DIFF
--- a/quasar/dbt/models/news_subscription/user_newsletter_subscriptions.sql
+++ b/quasar/dbt/models/news_subscription/user_newsletter_subscriptions.sql
@@ -2,13 +2,13 @@ SELECT DISTINCT
 	f.northstar_id,
 	f.newsletter_topic,
 	f.topic_subscribed_at::timestamptz,
-	CASE WHEN newsletters_unsubscribed_at IS NOT NULL
+	CASE WHEN topic_unsubscribed_at IS NOT NULL
+	    THEN topic_unsubscribed_at
+	    WHEN newsletters_unsubscribed_at IS NOT NULL
 	    THEN newsletters_unsubscribed_at
-	    WHEN topic_unsubscribed_at IS NOT NULL
-		THEN topic_unsubscribed_at
-		WHEN f.topic_updated_at = f.user_updated_at
-		THEN NULL
-		ELSE f.user_updated_at END AS topic_unsubscribed_at
+	    WHEN f.topic_updated_at = f.user_updated_at
+	    THEN NULL
+	    ELSE f.user_updated_at END AS topic_unsubscribed_at
 FROM (
 	SELECT DISTINCT
 		s.northstar_id AS northstar_id,


### PR DESCRIPTION
#### What's this PR do?
Collecting updates to the table to confirm it's accurate:

- A user unsubscribing from a topic should trump global unsubscribe (e.g. a check for if a user unsubs from a topic before unsubscribing completely) 

#### Where should the reviewer start?
user_newsletter_subscriptions.sql
#### How should this be manually tested?

- Confirm that topic_unsubscribed_at reflects the topic unsubscribed at date if it's earlier than the newsletter_unsubscribed_at date

#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
