### PR TITLE
Fixes outdated column names in campaign_info_international

### DIFF
--- a/quasar/dbt/models/campaign_info/campaign_info_international.sql
+++ b/quasar/dbt/models/campaign_info/campaign_info_international.sql
@@ -1,6 +1,6 @@
 SELECT 
-	c.id AS campaign_id,
-	c.internal_title AS campaign_name,
+	c.campaign_id,
+	c.campaign_name,
 	i.*
 FROM {{ ref('campaign_info_all') }} i
 LEFT JOIN {{ ref('campaign_info') }} c ON i.campaign_run_id = c.campaign_run_id


### PR DESCRIPTION
#### What's this PR do?
Fixes outdated column names `c.id` => `c.campaign_id` and `c.internal_title` => `c.campaign_name` in campaign_info_international
