### PR TITLE
Remove custom schema for messages_flattened model

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -84,7 +84,6 @@ models:
       gambit_messages:
         messages_flattened:
           alias: messages_flattened
-          schema: "{{ env_var('FT_GAMBIT') }}"
           materialized: table
           post-hook:
             - "CREATE INDEX IF NOT EXISTS messages_user_id ON {{ this }}(user_id)"


### PR DESCRIPTION
#### What's this PR do?
Removes custom schema in `messages_flattened` model. It will prevent it from being recreated in `ds_dbt_ft_gambit_conversations_api`.
