### PR TITLE
Adds derived table scripts to validate Gambit DBT pipeline

### DIFF
--- a/data/sql/derived-tables/mel_dbt_validation.sql
+++ b/data/sql/derived-tables/mel_dbt_validation.sql
@@ -1,0 +1,157 @@
+DROP MATERIALIZED VIEW IF EXISTS ds_dbt.member_event_log CASCADE;
+CREATE MATERIALIZED VIEW ds_dbt.member_event_log AS 
+(SELECT
+    MD5(concat(a.northstar_id, a."timestamp", a.action_id, a.action_serial_id)) AS event_id,
+    a.northstar_id AS northstar_id,
+    a."timestamp" AS "timestamp",
+    a."action" AS action_type,
+    a.action_id AS action_id,
+    a."source" AS "source",
+    a.action_serial_id AS action_serial_id,
+    a.channel AS channel,
+    CASE 
+    	WHEN date_trunc('month', a."timestamp") = date_trunc('month', u.created_at)
+    	THEN 'New' 
+    	ELSE 'Returning' END 
+    	AS "type",
+    MIN("timestamp")
+    	OVER 
+    	(PARTITION BY a.northstar_id, date_trunc('month', a."timestamp")) 
+    	AS first_action_month
+  FROM (
+    SELECT
+        DISTINCT s.northstar_id AS northstar_id,
+        s.created_at AS "timestamp",
+        'signup' AS "action",
+        '1' AS action_id, 
+        s."source" AS "source",
+        s.id::varchar AS action_serial_id,
+	(CASE WHEN s."source" ILIKE '%%sms%%' THEN 'sms'
+	WHEN s."source" NOT LIKE '%%sms%%'AND s."source" NOT LIKE '%%email%%' AND s."source" NOT LIKE '%%niche%%' OR s."source" IN ('rock-the-vote', 'turbovote') THEN 'web'
+	WHEN s."source" ILIKE '%%email%%' THEN 'email'
+	WHEN s."source" ILIKE '%%niche%%' THEN 'niche_coregistration'
+	WHEN s."source" NOT LIKE '%%sms%%'AND s."source" NOT LIKE '%%email%%' AND s."source" NOT LIKE '%%niche%%' AND s."source" NOT IN ('rock-the-vote', 'turbovote') AND s."source" IS NOT NULL THEN 'other' END) AS "channel"
+    FROM public.signups s
+    WHERE s."source" IS DISTINCT FROM 'importer-client'
+	AND s."source" IS DISTINCT FROM 'rock-the-vote'
+	AND s."source" IS DISTINCT FROM 'turbovote'
+    UNION ALL
+    SELECT
+        DISTINCT p.northstar_id AS northstar_id,
+        p.created_at AS "timestamp",
+        'post' AS "action",
+        '2' AS action_id,
+        p."source" AS "source",
+        p.id::varchar AS action_serial_id,
+	(CASE WHEN p."source" ILIKE '%%sms%%' THEN 'sms'
+	WHEN p."source" ILIKE '%%phoenix%%' OR p."source" IS NULL or p."source" ILIKE '%%turbovote%%' THEN 'web'
+	WHEN p."source" ILIKE '%%app%%' THEN 'mobile_app'
+	WHEN p."source" NOT LIKE '%%phoenix%%' AND p."source" NOT LIKE '%%sms%%' AND p."source" IS NOT NULL AND p."source" NOT LIKE '%%app%%' and p."source" NOT LIKE '%%turbovote%%' THEN 'other' END) AS "channel"
+    FROM public.posts p
+    WHERE p.status IN ('accepted', 'confirmed', 'register-OVR', 'register-form', 'pending')
+    UNION ALL
+    SELECT DISTINCT 
+        u_access.id AS northstar_id,
+        u_access.last_accessed_at AS "timestamp",
+        'site_access' AS "action",
+        '3' AS action_id,
+        NULL AS "source",
+        '0' AS action_serial_id,
+        'web' AS channel
+    FROM northstar.users u_access
+    WHERE u_access.last_accessed_at IS NOT NULL
+    AND u_access."source" IS DISTINCT FROM 'runscope'
+	AND u_access."source" IS DISTINCT FROM 'runscope-client'
+	AND u_access.email IS DISTINCT FROM 'runscope-scheduled-test@dosomething.org'
+	AND u_access.email IS DISTINCT FROM 'juy+runscopescheduledtests@dosomething.org'
+	AND (u_access.email NOT ILIKE '%%@example.org%%' OR u_access.email IS NULL) 
+    UNION ALL
+    SELECT DISTINCT 
+        u_login.id AS northstar_id,
+        u_login.last_authenticated_at AS "timestamp",
+        'site_login' AS "action",
+        '4' AS action_id,
+        NULL AS "source",
+        '0' AS action_serial_id,
+        'web' AS channel
+    FROM northstar.users u_login
+    WHERE u_login.last_authenticated_at IS NOT NULL 
+    AND u_login."source" IS DISTINCT FROM 'runscope'
+	AND u_login."source" IS DISTINCT FROM 'runscope-client'
+	AND u_login.email IS DISTINCT FROM 'runscope-scheduled-test@dosomething.org'
+	AND u_login.email IS DISTINCT FROM 'juy+runscopescheduledtests@dosomething.org'
+	AND (u_login.email NOT ILIKE '%%@example.org%%' OR u_login.email IS NULL) 
+    UNION ALL 
+    SELECT
+        DISTINCT u.id AS northstar_id,
+        u.created_at AS "timestamp",
+        'account_creation' AS action, 
+        '5' AS action_id,
+        u."source" AS "source",
+        '0' AS action_serial_id, 
+        (CASE WHEN u."source" ILIKE '%%sms%%' THEN 'sms'
+        WHEN u."source" ILIKE '%%phoenix%%' OR u."source" IS NULL THEN 'web'
+        WHEN u."source" ILIKE '%%niche%%' THEN 'niche_coregistration'
+        WHEN u."source" NOT LIKE '%%niche%%' AND u."source" NOT LIKE '%%sms%%' AND u."source" NOT LIKE '%%phoenix%%' AND u."source" IS NOT NULL THEN 'other' END) AS "channel"
+    FROM
+        (SELECT 
+                u_create.id,
+                max(u_create."source") AS "source",
+                min(u_create.created_at) AS created_at
+        FROM northstar.users u_create
+	WHERE u_create."source" IS DISTINCT FROM 'importer-client'
+	AND u_create."source" IS DISTINCT FROM 'runscope'
+	AND u_create."source" IS DISTINCT FROM 'runscope-client'
+	AND u_create.email IS DISTINCT FROM 'runscope-scheduled-test@dosomething.org'
+	AND u_create.email IS DISTINCT FROM 'juy+runscopescheduledtests@dosomething.org'
+	AND (u_create.email NOT ILIKE '%%@example.org%%' OR u_create.email IS NULL) 
+        GROUP BY u_create.id) u
+    UNION ALL 
+    SELECT
+        DISTINCT g.user_id AS northstar_id,
+        g.created_at AS "timestamp",
+        'messaged_gambit' AS "action", 
+        '6' AS action_id,
+        'SMS' AS "source",
+        g.message_id AS action_serial_id,
+        'sms' AS "channel"
+    FROM
+        ds_dbt.gambit_messages_inbound g
+    WHERE 
+    	g.user_id IS NOT NULL
+    	AND g.macro <> 'subscriptionStatusStop' 
+    UNION ALL 
+        SELECT
+            DISTINCT cio.customer_id AS northstar_id,
+            cio."timestamp" AS "timestamp",
+            'clicked_link' AS "action",
+            '7' AS action_id,
+            cio.template_id::CHARACTER AS "source",
+            cio.event_id AS action_serial_id, 
+            'email' AS "channel"
+        FROM
+            cio.email_event cio
+        WHERE 
+            cio.event_type = 'email_clicked'
+	    AND cio.customer_id IS NOT NULL
+    UNION ALL 
+    SELECT DISTINCT
+        b.northstar_id AS northstar_id,
+        b.click_time AS "timestamp",
+        CONCAT('bertly_link_', b.interaction_type) AS "action",
+        '10' AS action_id,
+        'bertly' AS "source",
+        b.click_id AS action_serial_id,
+        b."source" AS "channel"
+    FROM public.bertly_clicks b
+    INNER JOIN public.users u
+    ON b.northstar_id = u.northstar_id
+    WHERE b.northstar_id IS NOT NULL
+    AND b.interaction_type IS DISTINCT FROM 'preview'
+    ) AS a
+ LEFT JOIN public.users u ON u.northstar_id = a.northstar_id
+   );
+CREATE UNIQUE INDEX ON ds_dbt.member_event_log ("timestamp", northstar_id, event_id);
+CREATE INDEX ON ds_dbt.member_event_log (northstar_id, "timestamp");
+GRANT SELECT ON ds_dbt.member_event_log TO looker;
+GRANT SELECT ON ds_dbt.member_event_log TO dsanalyst;

--- a/data/sql/derived-tables/user_activity_dbt_validation.sql
+++ b/data/sql/derived-tables/user_activity_dbt_validation.sql
@@ -1,0 +1,169 @@
+DROP MATERIALIZED VIEW IF EXISTS ds_dbt.user_activity CASCADE;
+CREATE MATERIALIZED VIEW user_activity AS (
+    WITH
+	rb_summary AS (
+	    SELECT
+		r_with_lag.northstar_id,
+		sum(r_with_lag.reportback_volume) AS total_quantity,
+		count(DISTINCT r_with_lag.campaign_id) AS num_rbs,
+		max(r_with_lag.post_created_at) AS most_recent_rb,
+		min(r_with_lag.post_created_at) AS first_rb,
+		avg(r_with_lag.time_betw_rbs) AS avg_time_betw_rbs
+	    FROM (
+		SELECT
+		    *,
+		    post_created_at - lag(post_created_at) OVER (
+			PARTITION BY northstar_id ORDER BY post_created_at) AS time_betw_rbs
+		FROM public.reportbacks
+	    ) r_with_lag
+	    GROUP BY r_with_lag.northstar_id
+	),
+	gambit_unsub AS (
+	    SELECT
+		f.user_id,
+		CASE WHEN f.last_macro = 'subscriptionStatusStop' OR f.last_topic = 'unsubscribed'
+		THEN f.last_ts ELSE NULL END AS unsub_ts
+	    FROM (
+		SELECT DISTINCT
+		    user_id,
+		    LAST_VALUE(macro) OVER (PARTITION BY user_id ORDER BY created_at
+			RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS last_macro,
+		    LAST_VALUE(topic) OVER (PARTITION BY user_id ORDER BY created_at
+			RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS last_topic,
+		    LAST_VALUE(created_at) OVER (PARTITION BY user_id ORDER BY created_at
+			RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS last_ts
+		FROM ds_dbt.gambit_messages_inbound
+	    ) f
+	),
+	sms_undeliverable AS (
+	    SELECT DISTINCT
+		    id,
+		    FIRST_VALUE(updated_at) OVER (PARTITION BY id ORDER BY updated_at
+			ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS unsub_ts
+	    FROM northstar.users
+	    WHERE sms_status IN ('unknown', 'undeliverable', 'GDPR')
+	),
+	email_unsub AS (
+	    SELECT
+		f.customer_id,
+		CASE WHEN f.last_status = 'customer_unsubscribed' THEN f.last_ts ELSE NULL
+		    END AS email_unsubscribed_at
+	    FROM (
+		SELECT DISTINCT
+		    customer_id,
+		    LAST_VALUE("timestamp") OVER (
+			PARTITION BY customer_id ORDER BY "timestamp", event_type
+			RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS last_ts,
+		    LAST_VALUE(event_type) OVER (
+			PARTITION BY customer_id ORDER BY "timestamp", event_type
+			RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS last_status
+		    FROM cio.customer_event
+	    ) f
+	),
+	time_to_actions AS (
+	    SELECT
+		f.northstar_id,
+		avg(date_part('day', f.time_to_next_action)) AS avg_days_next_action_after_rb,
+		min(date_part('day', f.time_to_next_action_last_rb)) AS days_to_next_action_after_last_rb
+	    FROM (
+		SELECT
+		    r.northstar_id,
+		    mel.next_action_ts - r.post_created_at AS time_to_next_action,
+		    LAST_VALUE(mel.next_action_ts - r.post_created_at) OVER (
+			PARTITION BY r.northstar_id ORDER BY r.post_created_at
+			ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+		    ) AS time_to_next_action_last_rb
+		FROM public.reportbacks r
+		LEFT JOIN LATERAL (
+		    SELECT "timestamp" AS next_action_ts, action_type AS next_action_type
+		    FROM ds_dbt.member_event_log
+		    WHERE northstar_id = r.northstar_id AND "timestamp" > r.post_created_at
+		    ORDER BY "timestamp" ASC
+		    LIMIT 1
+		) mel
+		ON TRUE
+	    ) f
+	    GROUP BY f.northstar_id
+	)
+    SELECT
+	u.northstar_id,
+	u.created_at,
+	u.sms_status,
+	u.cio_status AS email_status,
+	s.num_signups,
+	s.most_recent_signup,
+	r.num_rbs,
+	r.total_quantity,
+	r.most_recent_rb,
+	r.first_rb,
+	r.avg_time_betw_rbs,
+	time_to_actions.avg_days_next_action_after_rb,
+	time_to_actions.days_to_next_action_after_last_rb,
+	mel.most_recent_action AS most_recent_mam_action,
+	email_opens.most_recent_email_open,
+	greatest(
+	    mel.most_recent_action,
+	    email_opens.most_recent_email_open
+	) AS most_recent_all_actions,
+	CASE WHEN time_to_actions.days_to_next_action_after_last_rb IS NULL
+	    AND r.num_rbs > 0 THEN TRUE END AS last_action_is_rb,
+	DATE_PART(
+	    'day', now() - greatest(mel.most_recent_action, email_opens.most_recent_email_open)
+	) as days_since_last_action,
+	(r.first_rb - u.created_at) AS time_to_first_rb,
+	COALESCE(gambit_unsub.unsub_ts, sms_undeliverable.unsub_ts) AS sms_unsubscribed_at,
+	email_unsub.email_unsubscribed_at,
+	CASE WHEN u.subscribed_member IS FALSE
+	    THEN greatest(
+		gambit_unsub.unsub_ts,
+		sms_undeliverable.unsub_ts,
+		email_unsub.email_unsubscribed_at) ELSE NULL
+	    END AS user_unsubscribed_at,
+	CASE WHEN u."source" = 'importer-client' AND p.first_post = 'voter-reg'
+	    THEN 1 ELSE 0 END AS voter_reg_acquisition
+    FROM public.users u
+    LEFT JOIN (
+	SELECT
+	    northstar_id,
+	    count(DISTINCT campaign_id) AS num_signups,
+	    max(created_at) AS most_recent_signup
+	FROM public.signups
+	GROUP BY northstar_id
+    ) s
+	ON u.northstar_id = s.northstar_id
+    LEFT JOIN rb_summary r
+	ON u.northstar_id = r.northstar_id
+    LEFT JOIN (
+	    SELECT northstar_id, max("timestamp") AS most_recent_action
+	    FROM ds_dbt.member_event_log
+	    GROUP BY northstar_id
+	) mel
+	ON u.northstar_id = mel.northstar_id
+    LEFT JOIN (
+	    SELECT customer_id, max("timestamp") AS most_recent_email_open
+	    FROM cio.email_event
+	    WHERE event_type = 'email_opened'
+	    GROUP BY customer_id
+	) email_opens
+	ON u.northstar_id = email_opens.customer_id
+    LEFT JOIN gambit_unsub
+	ON u.northstar_id = gambit_unsub.user_id
+    LEFT JOIN sms_undeliverable
+	ON u.northstar_id = sms_undeliverable.id
+    LEFT JOIN email_unsub
+	ON u.northstar_id = email_unsub.customer_id
+    LEFT JOIN time_to_actions
+	ON u.northstar_id = time_to_actions.northstar_id
+    LEFT JOIN (
+	    SELECT DISTINCT
+		northstar_id,
+		FIRST_VALUE("type") OVER (
+		    PARTITION BY northstar_id ORDER BY created_at) AS first_post
+	    FROM public.posts
+	) p
+	ON u.northstar_id = p.northstar_id
+);
+CREATE UNIQUE INDEX ON ds_dbt.user_activity (created_at, northstar_id);
+CREATE INDEX ON ds_dbt.user_activity (most_recent_all_actions);
+GRANT SELECT ON ds_dbt.user_activity TO looker;
+GRANT SELECT ON ds_dbt.user_activity TO dsanalyst;

--- a/quasar/mel.py
+++ b/quasar/mel.py
@@ -4,6 +4,8 @@ from .sql_utils import run_sql_file_raw, refresh_materialized_view
 def create():
     run_sql_file_raw('./data/sql/derived-tables/mel.sql')
 
+def create_for_dbt_validation():
+    run_sql_file_raw('../data/sql/derived-tables/mel_dbt_validation.sql')
 
 def refresh():
     refresh_materialized_view('public.member_event_log')

--- a/quasar/mel.py
+++ b/quasar/mel.py
@@ -4,8 +4,10 @@ from .sql_utils import run_sql_file_raw, refresh_materialized_view
 def create():
     run_sql_file_raw('./data/sql/derived-tables/mel.sql')
 
+
 def create_for_dbt_validation():
     run_sql_file_raw('./data/sql/derived-tables/mel_dbt_validation.sql')
+
 
 def refresh():
     refresh_materialized_view('public.member_event_log')

--- a/quasar/mel.py
+++ b/quasar/mel.py
@@ -5,7 +5,7 @@ def create():
     run_sql_file_raw('./data/sql/derived-tables/mel.sql')
 
 def create_for_dbt_validation():
-    run_sql_file_raw('../data/sql/derived-tables/mel_dbt_validation.sql')
+    run_sql_file_raw('./data/sql/derived-tables/mel_dbt_validation.sql')
 
 def refresh():
     refresh_materialized_view('public.member_event_log')

--- a/quasar/user_activity.py
+++ b/quasar/user_activity.py
@@ -6,7 +6,8 @@ def create():
 
 
 def create_for_dbt_validation():
-    run_sql_file_raw('./data/sql/derived-tables/user_activity_dbt_validation.sql')
+    run_sql_file_raw(''.join(("./data/sql/derived-tables/"
+    	                      "user_activity_dbt_validation.sql")))
 
 
 def refresh():

--- a/quasar/user_activity.py
+++ b/quasar/user_activity.py
@@ -4,8 +4,10 @@ from .sql_utils import run_sql_file_raw, refresh_materialized_view
 def create():
     run_sql_file_raw('./data/sql/derived-tables/user_activity.sql')
 
+
 def create_for_dbt_validation():
     run_sql_file_raw('./data/sql/derived-tables/user_activity_dbt_validation.sql')
+
 
 def refresh():
     refresh_materialized_view('public.user_activity')

--- a/quasar/user_activity.py
+++ b/quasar/user_activity.py
@@ -7,7 +7,7 @@ def create():
 
 def create_for_dbt_validation():
     run_sql_file_raw(''.join(("./data/sql/derived-tables/"
-    	                      "user_activity_dbt_validation.sql")))
+                              "user_activity_dbt_validation.sql")))
 
 
 def refresh():

--- a/quasar/user_activity.py
+++ b/quasar/user_activity.py
@@ -4,6 +4,8 @@ from .sql_utils import run_sql_file_raw, refresh_materialized_view
 def create():
     run_sql_file_raw('./data/sql/derived-tables/user_activity.sql')
 
+def create_for_dbt_validation():
+    run_sql_file_raw('./data/sql/derived-tables/user_activity_dbt_validation.sql')
 
 def refresh():
     refresh_materialized_view('public.user_activity')

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
             'users_create = quasar.users:create',
             'users_refresh = quasar.users:refresh',
             'user_activity_create = quasar.user_activity:create',
+            'user_activity_create_for_dbt_validation = quasar.user_activity:create_for_dbt_validation',
             'user_activity_refresh = quasar.user_activity:refresh'
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = convert_deps_to_pip(pfile['packages'], r=False)
 
 setup(
     name="quasar",
-    version="2019.10.31.0",
+    version="2019.11.01.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={
@@ -26,6 +26,7 @@ setup(
             'gambit_messages_refresh = quasar.gambit:refresh_gambit_messages',
             'gdpr = quasar.gdpr_comply:gdpr_from_file',
             'mel_create = quasar.mel:create',
+            'mel_create_for_dbt_validation = quasar.mel:create_for_dbt_validation',
             'mel_refresh = quasar.mel:refresh',
             'northstar_backfill = quasar.northstar_to_user_table:backfill',
             'northstar_full_backfill = quasar.northstar_to_user_table_full_backfill:backfill',


### PR DESCRIPTION
#### What's this PR do?
Based on the plan [here](https://dosomething.slack.com/archives/GPX65V4GL/p1572642715031300). It adds two scripts that will run in parallel with MEL and User Activity recreates in Prod. They will create the same tables in the `dbt_schema` but will use the Gambit messages tables generated by the DBT pipeline.
