### PR TITLE
Fix: creates materialized view inside ds_dbt schema

### DIFF
--- a/data/sql/derived-tables/user_activity_dbt_validation.sql
+++ b/data/sql/derived-tables/user_activity_dbt_validation.sql
@@ -1,5 +1,5 @@
 DROP MATERIALIZED VIEW IF EXISTS ds_dbt.user_activity CASCADE;
-CREATE MATERIALIZED VIEW user_activity AS (
+CREATE MATERIALIZED VIEW ds_dbt.user_activity AS (
     WITH
 	rb_summary AS (
 	    SELECT


### PR DESCRIPTION
#### What's this PR do?
Fixes a typo that causes the `user_activity` view to be created in the `public` schema instead of `ds_dbt`.

Sorry for the 🌃PR @sheyd ! 
