### PR TITLE
update logic for post bucket

### DIFF
--- a/quasar/dbt/models/campaign_activity/reportbacks.sql
+++ b/quasar/dbt/models/campaign_activity/reportbacks.sql
@@ -20,13 +20,13 @@ SELECT
         THEN 'self-reported registrations'
         WHEN (pd.post_class ilike '%%vote%%' AND pd.status <> 'confirmed')
         THEN 'voter_registrations'
-        WHEN pd.post_class ilike '%%photo%%'
+        WHEN pd.post_type ilike '%%photo%%' AND pd.post_class NOT ilike '%%vote%%'
         THEN 'photo_rbs'
-        WHEN pd.post_class ilike '%%text%%'
+        WHEN pd.post_type ilike '%%text%%'
         THEN 'text_rbs'
-        WHEN pd.post_class ilike '%%social%%'
+        WHEN pd.post_type ilike '%%social%%'
         THEN 'social'
-        WHEN pd.post_class ilike '%%call%%'
+        WHEN pd.post_type ilike '%%call%%'
         THEN 'phone_calls'
         ELSE NULL END AS post_bucket
 FROM {{ ref('posts') }} pd


### PR DESCRIPTION
#### What's this PR do?
There's a bug in how we group reportbacks in the `post_bucket` field. The old logic was mistakenly classifying social shares as text RBs because the substring 'text' was in the `post_class` field. We use the `post_class` field in order to identify voter registrations but can use the `post_type` field in order to correctly classify the non-VR reportbacks. 

Tej originally identified here: https://dosomething.slack.com/archives/C03T8SDJG/p1573131881023100
 
#### Where should the reviewer start?
reportbacks.sql

#### How should this be manually tested?
I confirmed that the only campaigns for which there's an update to the RB post_bucket based on this new logic is `9032` (the campaign that Tej had flagged) and `9014` (which had the same error).

#### Screenshots (if appropriate)
#### Questions:
