### PR TITLE
Points to public user activity tables in dbt validation jobs

### DIFF
--- a/data/sql/derived-tables/mel_dbt_validation.sql
+++ b/data/sql/derived-tables/mel_dbt_validation.sql
@@ -31,7 +31,7 @@ CREATE MATERIALIZED VIEW ds_dbt.member_event_log AS
 	WHEN s."source" ILIKE '%%email%%' THEN 'email'
 	WHEN s."source" ILIKE '%%niche%%' THEN 'niche_coregistration'
 	WHEN s."source" NOT LIKE '%%sms%%'AND s."source" NOT LIKE '%%email%%' AND s."source" NOT LIKE '%%niche%%' AND s."source" NOT IN ('rock-the-vote', 'turbovote') AND s."source" IS NOT NULL THEN 'other' END) AS "channel"
-    FROM ds_dbt.signups s
+    FROM public.signups s
     WHERE s."source" IS DISTINCT FROM 'importer-client'
 	AND s."source" IS DISTINCT FROM 'rock-the-vote'
 	AND s."source" IS DISTINCT FROM 'turbovote'
@@ -47,7 +47,7 @@ CREATE MATERIALIZED VIEW ds_dbt.member_event_log AS
 	WHEN p."source" ILIKE '%%phoenix%%' OR p."source" IS NULL or p."source" ILIKE '%%turbovote%%' THEN 'web'
 	WHEN p."source" ILIKE '%%app%%' THEN 'mobile_app'
 	WHEN p."source" NOT LIKE '%%phoenix%%' AND p."source" NOT LIKE '%%sms%%' AND p."source" IS NOT NULL AND p."source" NOT LIKE '%%app%%' and p."source" NOT LIKE '%%turbovote%%' THEN 'other' END) AS "channel"
-    FROM ds_dbt.posts p
+    FROM public.posts p
     WHERE p.status IN ('accepted', 'confirmed', 'register-OVR', 'register-form', 'pending')
     UNION ALL
     SELECT DISTINCT 

--- a/data/sql/derived-tables/user_activity_dbt_validation.sql
+++ b/data/sql/derived-tables/user_activity_dbt_validation.sql
@@ -14,7 +14,7 @@ CREATE MATERIALIZED VIEW ds_dbt.user_activity AS (
 		    *,
 		    post_created_at - lag(post_created_at) OVER (
 			PARTITION BY northstar_id ORDER BY post_created_at) AS time_betw_rbs
-		FROM ds_dbt.reportbacks
+		FROM public.reportbacks
 	    ) r_with_lag
 	    GROUP BY r_with_lag.northstar_id
 	),
@@ -73,7 +73,7 @@ CREATE MATERIALIZED VIEW ds_dbt.user_activity AS (
 			PARTITION BY r.northstar_id ORDER BY r.post_created_at
 			ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
 		    ) AS time_to_next_action_last_rb
-		FROM ds_dbt.reportbacks r
+		FROM public.reportbacks r
 		LEFT JOIN LATERAL (
 		    SELECT "timestamp" AS next_action_ts, action_type AS next_action_type
 		    FROM ds_dbt.member_event_log
@@ -127,7 +127,7 @@ CREATE MATERIALIZED VIEW ds_dbt.user_activity AS (
 	    northstar_id,
 	    count(DISTINCT campaign_id) AS num_signups,
 	    max(created_at) AS most_recent_signup
-	FROM ds_dbt.signups
+	FROM public.signups
 	GROUP BY northstar_id
     ) s
 	ON u.northstar_id = s.northstar_id
@@ -159,7 +159,7 @@ CREATE MATERIALIZED VIEW ds_dbt.user_activity AS (
 		northstar_id,
 		FIRST_VALUE("type") OVER (
 		    PARTITION BY northstar_id ORDER BY created_at) AS first_post
-	    FROM ds_dbt.posts
+	    FROM public.posts
 	) p
 	ON u.northstar_id = p.northstar_id
 );


### PR DESCRIPTION
#### What's this PR do?
Updates the `user_activity_dbt_validation.sql` and `mel_dbt_validation.sql` queries to use the new campaign activity DBT pipeline.
