### PR TITLE
Fixes reference in user_activity_dbt_validation.sql

### DIFF
--- a/data/sql/derived-tables/mel_dbt_validation.sql
+++ b/data/sql/derived-tables/mel_dbt_validation.sql
@@ -144,12 +144,12 @@ CREATE MATERIALIZED VIEW ds_dbt.member_event_log AS
         b.click_id AS action_serial_id,
         b."source" AS "channel"
     FROM public.bertly_clicks b
-    INNER JOIN public.users u
+    INNER JOIN ds_dbt.users u
     ON b.northstar_id = u.northstar_id
     WHERE b.northstar_id IS NOT NULL
     AND b.interaction_type IS DISTINCT FROM 'preview'
     ) AS a
- LEFT JOIN public.users u ON u.northstar_id = a.northstar_id
+ LEFT JOIN ds_dbt.users u ON u.northstar_id = a.northstar_id
    );
 CREATE UNIQUE INDEX ON ds_dbt.member_event_log ("timestamp", northstar_id, event_id);
 CREATE INDEX ON ds_dbt.member_event_log (northstar_id, "timestamp");

--- a/data/sql/derived-tables/user_activity_dbt_validation.sql
+++ b/data/sql/derived-tables/user_activity_dbt_validation.sql
@@ -121,7 +121,7 @@ CREATE MATERIALIZED VIEW ds_dbt.user_activity AS (
 	    END AS user_unsubscribed_at,
 	CASE WHEN u."source" = 'importer-client' AND p.first_post = 'voter-reg'
 	    THEN 1 ELSE 0 END AS voter_reg_acquisition
-    FROM public.users u
+    FROM ds_dbt.users u
     LEFT JOIN (
 	SELECT
 	    northstar_id,


### PR DESCRIPTION
#### What's this PR do?
Fixes reference to `public.users`. It should reference `ds_dbt.users` to test the users DBT pipeline dependency of the user_activity view.