### PR TITLE
Fix index creation syntax error in users DBT model

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -155,7 +155,7 @@ models:
           alias: users
           materialized: table
           post-hook:
-           - "CREATE UNIQUE INDEX IF NOT EXISTS du_indicies ON {{ this }}(northstar_id, created_at, email, mobile, 'source')"
+           - "CREATE UNIQUE INDEX IF NOT EXISTS du_indicies ON {{ this }}(northstar_id, created_at, email, mobile, source)"
            - "GRANT SELECT ON {{ this }} TO dsanalyst"
            - "GRANT SELECT ON {{ this }} TO looker"
            - "GRANT SELECT ON {{ this }} TO public"


### PR DESCRIPTION
#### What's this PR do?
Removes quotes in `'source'` to fix this error:

```
Database Error in model users (models/users_table/users.sql)
  syntax error at or near "'source'"
  LINE 2: ..."."users"(northstar_id, created_at, email, mobile, 'source')
                                                                ^
  compiled SQL at ../../docs/compiled/ds_dbt/users_table/users.sql
```