### PR TITLE
Using updated DBT Snowflake Connector to fix dep issues

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,9 +28,9 @@ xmltodict = "*"
 pydash = "*"
 python-dateutil = "==2.6.1"
 SQLAlchemy = "*"
-dbt = "==0.14.0"
+dbt = "==0.14.4"
+dbt-snowflake = "*"
 pipenv = "*"
-snowflake-connector-python = "*"
 sh = "*"
 
 [requires]


### PR DESCRIPTION
#### What's this PR do?
This PR bumps up the DBT version to `v0.14.4` and uses the new name for the dbt connector to install the snowflake connector. 

#### Where should the reviewer start?
#### How should this be manually tested?

#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:

@rapala61 found the fix here - https://github.com/fishtown-analytics/dbt/releases/tag/v0.14.4
