### PR TITLE
Adds northstar_users_deduped model.

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -163,6 +163,16 @@ models:
           alias: northstar_users_raw
           materialized: table
           post-hook:
+           - "CREATE INDEX IF NOT EXISTS northstar_users_raw_northstar_id_updated_at_i ON {{ this }}(northstar_id, updated_at)"
+           - "CREATE INDEX IF NOT EXISTS northstar_users_raw_northstar_id_updated_at_dbt_scd_id_idx ON {{ this }}(northstar_id DESC, updated_at DESC, dbt_scd_id DESC)"
+           - "GRANT SELECT ON {{ this }} TO dsanalyst"
+           - "GRANT SELECT ON {{ this }} TO looker"
+           - "GRANT SELECT ON {{ this }} TO public"
+        northstar_users_deduped:
+          alias: northstar_users_deduped
+          materialized: table
+          post-hook:
+           - "CREATE INDEX IF NOT EXISTS northstar_users_deduped_northstar_id_updated_at_i ON {{ this }}(northstar_id, updated_at)"
            - "GRANT SELECT ON {{ this }} TO dsanalyst"
            - "GRANT SELECT ON {{ this }} TO looker"
            - "GRANT SELECT ON {{ this }} TO public"

--- a/quasar/dbt/models/users_table/northstar_users_deduped.sql
+++ b/quasar/dbt/models/users_table/northstar_users_deduped.sql
@@ -1,0 +1,2 @@
+SELECT DISTINCT ON (northstar_id, updated_at) *
+FROM {{ ref('northstar_users_raw') }}

--- a/quasar/dbt/models/users_table/northstar_users_raw.sql
+++ b/quasar/dbt/models/users_table/northstar_users_raw.sql
@@ -45,7 +45,7 @@ SELECT
 	nus.causes::jsonb,
 	nus.school_id
 FROM {{ env_var('NORTHSTAR_FT_SCHEMA') }}.northstar_users_snapshot nus
-UNION
+UNION ALL
 SELECT
 	nu.id,
 	nu.country,

--- a/quasar/dbt/models/users_table/users.sql
+++ b/quasar/dbt/models/users_table/users.sql
@@ -39,7 +39,7 @@ SELECT
 		THEN TRUE ELSE FALSE END AS subscribed_member,
 	umax.max_update AS last_updated_at,
 	u.school_id
-FROM {{ ref('northstar_users_raw') }} u
+FROM {{ ref('northstar_users_deduped') }} u
 INNER JOIN
 	(SELECT
 		utemp.id,
@@ -47,7 +47,7 @@ INNER JOIN
 		max(utemp.last_accessed_at) AS max_last_access,
 		max(utemp.last_authenticated_at) AS max_last_auth,
 		max(utemp.last_messaged_at) AS max_last_message
-	FROM northstar.users utemp
+	FROM {{ ref('northstar_users_deduped') }} utemp
 	GROUP BY utemp.id) umax ON umax.id = u.id AND umax.max_update = u.updated_at
 LEFT JOIN {{ ref('cio_latest_status') }} email_status ON email_status.customer_id = u.id
 WHERE


### PR DESCRIPTION
#### What's this PR do?
- It adds a `northstar_users_deduped` DBT model. This model will eliminate duplicate logs product of joining the DBT Snapshot table and the NS Scraper log table (attempting to keep the DBT Snapshot version). 
#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/170897721
