### PR TITLE
Running clean to drop databases before restoring

### DIFF
--- a/quasar/prod_to_qa.py
+++ b/quasar/prod_to_qa.py
@@ -31,7 +31,7 @@ def main():
             '-U', prod_pg_opts['username'],
             '-d', prod_pg_opts['database'],
             '--schema', schema,
-            '-O', '--no-acl', '-v', _piped=True),
+            '-O', '--no-acl', '-v', '--clean', _piped=True),
             '-h', qa_pg_opts['host'],
             '-U', qa_pg_opts['username'],
             '-d', qa_pg_opts['database']


### PR DESCRIPTION
#### What's this PR do?
This PR adds the `-c` flag to the pg_dump command to drop tables before recreating and dumping the updated data. Without this flag we're getting duplicate records.
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/n/projects/2076969/stories/171092495
#### Screenshots (if appropriate)
#### Questions:
