### PR TITLE
Fix action for phoenix_clicked_voter_registration_action events

### DIFF
--- a/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
@@ -1,4 +1,4 @@
-SELECT 
+SELECT
     event_id AS event_id,
     app_id AS event_source,
     collector_tstamp AS event_datetime,
@@ -8,7 +8,14 @@ SELECT
     page_urlpath AS "path",
     page_urlquery AS query_parameters,
     se_category,
-    se_action,
+    -- https://www.pivotaltracker.com/story/show/171161608
+    CASE
+      WHEN
+        (se_property = 'phoenix_clicked_voter_registration_action' AND se_action = 'undefined_clicked')
+      THEN
+        'button_clicked'
+      ELSE
+        se_action END AS se_action,
     se_label,
     domain_sessionid AS session_id,
     domain_sessionidx AS session_counter,

--- a/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
@@ -13,7 +13,7 @@ SELECT
         -- https://www.pivotaltracker.com/story/show/171161608
         ((se_property = 'phoenix_clicked_voter_registration_action' AND se_action = 'undefined_clicked')
         OR
-        --https://www.pivotaltracker.com/story/show/171392390
+        -- https://www.pivotaltracker.com/story/show/171392080
         (se_property = 'phoenix_clicked_nav_button_search_form_toggle' and se_action = 'link_clicked'))
       THEN
         'button_clicked'


### PR DESCRIPTION
#### What's this PR do?
- Sets action to `button_clicked` for `phoenix_clicked_voter_registration_action` events that have `undefined_clicked` actions. 
#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/171161608

