### PR TITLE
Fixes phoenix_failed_call_to_action_popover_submission event name 

### DIFF
--- a/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
@@ -2,7 +2,14 @@ SELECT
     event_id AS event_id,
     app_id AS event_source,
     collector_tstamp AS event_datetime,
-    se_property AS event_name,
+    CASE
+      WHEN
+        -- https://www.pivotaltracker.com/story/show/171388718
+        se_property = 'phoenix_failed_call_to_action_popover_submission'
+      THEN
+        'phoenix_failed_call_to_action_popover'
+      ELSE
+        se_property END AS event_name,
     "event" AS event_type,
     page_urlhost AS host,
     page_urlpath AS "path",
@@ -19,7 +26,14 @@ SELECT
         'button_clicked'
       ELSE
         se_action END AS se_action,
-    se_label,
+    CASE
+      WHEN
+        -- https://www.pivotaltracker.com/story/show/171388718
+        se_property = 'phoenix_failed_call_to_action_popover_submission'
+      THEN
+        'call_to_action_popover'
+      ELSE
+        se_label END AS se_label,
     domain_sessionid AS session_id,
     domain_sessionidx AS session_counter,
     dvce_type AS browser_size,

--- a/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
@@ -29,7 +29,7 @@ SELECT
     CASE
       WHEN
         -- https://www.pivotaltracker.com/story/show/171388718
-        se_property = 'phoenix_failed_call_to_action_popover_submission'
+        se_property = 'phoenix_failed_call_to_action_popover_submission' AND se_label = 'call_to_action_popover_submission'
       THEN
         'call_to_action_popover'
       ELSE


### PR DESCRIPTION
### What's this PR do?
- Updates `phoenix_failed_call_to_action_popover_submission` event to `phoenix_failed_call_to_action_popover`.
    - Updates it's label from `call_to_action_popover_submission` to `call_to_action_popover`

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/171388718
