### PR TITLE
Adding new Rogue Posts snapshot

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -282,3 +282,4 @@ models:
           post-hook:
             - "GRANT SELECT ON {{ this }} to dsanalyst"
             - "GRANT SELECT ON {{ this }} to looker"
+

--- a/quasar/dbt/snapshots/rogue_posts.sql
+++ b/quasar/dbt/snapshots/rogue_posts.sql
@@ -1,0 +1,20 @@
+/*
+  This snapshot table will live in:
+    ft_dosomething_rogue.rogue_posts
+*/
+
+{% snapshot rogue_posts_snapshot %}
+
+    {{
+        config(
+          target_database=env_var("NORTHSTAR_TARGET_DB"),
+          target_schema=env_var("FT_ROGUE"),
+          unique_key='id',
+          strategy='timestamp',
+          updated_at='updated_at',
+        )
+    }}
+    
+    select * from {{ env_var('FT_ROGUE') }}.posts
+    
+{% endsnapshot %}


### PR DESCRIPTION
#### What's this PR do?
This adds the snapshot code for the Rogue posts table. A Jenkins job in QA won't tell us much about whether we're getting the data we want, so this may have to go to prod to test that we're getting all the data we want from the prod Rogue DB.

#### Where should the reviewer start?
#### How should this be manually tested?
In QA a look at the `quasar_prod_dump.ft_rogue_dosomething.rogue_posts_snapshots` or `ft_rogue_dosomething_rogue_qa.rogue_posts_snapshots`. 

#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/n/projects/2076969/stories/170735454

#### Screenshots (if appropriate)
#### Notes:
There are some additional settings we can add to control post hooks and the like in the dbt_project.yml file, but those aren't supported in v0.14. Rather than go down a rabbit hole, we can just add those if necessary after upgrading.

We'll also need to potentially update the Northstar snapshot jobs in QA and prod so that we have more granular control over whether we're running the Northstar or the Rogue posts snapshot job.
