### PR TITLE
Updating ETL script to use northstar_users_deduped

### DIFF
--- a/quasar/etl_monitoring.py
+++ b/quasar/etl_monitoring.py
@@ -55,7 +55,7 @@ class ETLMonitoring:
 
         self.etl_queries = {
             'raw_northstar':
-                'SELECT count(*) FROM northstar.users',
+                'SELECT count(*) FROM public.northstar_users_deduped',
             'raw_rogue_signups':
                 'SELECT count(*) FROM ft_dosomething_rogue.signups',
             'raw_rogue_posts':

--- a/quasar/etl_monitoring.py
+++ b/quasar/etl_monitoring.py
@@ -55,7 +55,7 @@ class ETLMonitoring:
 
         self.etl_queries = {
             'raw_northstar':
-                'SELECT count(*) FROM public.northstar_users_deduped',
+                'SELECT count(*) FROM northstar_ft_userapi.northstar_users_snapshot',
             'raw_rogue_signups':
                 'SELECT count(*) FROM ft_dosomething_rogue.signups',
             'raw_rogue_posts':


### PR DESCRIPTION
#### What's this PR do?
This PR updates the ETL monitoring script to check the Northstar snapshot table instead of `northstar.users` since we've turned off the Northstar scraper.
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/n/projects/2076969/stories/171816724
#### Screenshots (if appropriate)
#### Questions:
