### PR TITLE
Adding OVRD DBT models

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -246,6 +246,22 @@ models:
             - "CREATE INDEX ON {{ this }}(northstar_id)"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"
             - "GRANT SELECT ON {{ this }} TO looker"
+        ovrd_recipient_funnel:
+          alias: ovrd_recipient_funnel
+          materialized: table
+          post-hook:
+            - "CREATE UNIQUE INDEX IF NOT EXISTS ovrd_r_index ON {{ this }}(northstar_id)"
+            - "CREATE INDEX ON {{ this }}(northstar_id)"
+            - "GRANT SELECT ON {{ this }} TO dsanalyst"
+            - "GRANT SELECT ON {{ this }} TO looker"
+        ovrd_creator_funnel:
+          alias: ovrd_creator_funnel
+          materialized: table
+          post-hook:
+            - "CREATE UNIQUE INDEX IF NOT EXISTS ovrd_index ON {{ this }}(northstar_id, device_id)"
+            - "CREATE INDEX ON {{ this }}(northstar_id)"
+            - "GRANT SELECT ON {{ this }} TO dsanalyst"
+            - "GRANT SELECT ON {{ this }} TO looker"
       tmc_users:
         tmc_users_out:
           alias: tmc_users_out

--- a/quasar/dbt/models/user_journey/ovrd_creator_funnel.sql
+++ b/quasar/dbt/models/user_journey/ovrd_creator_funnel.sql
@@ -1,0 +1,128 @@
+WITH best_nsid AS (
+	SELECT 
+		ranked.device_id,
+		ranked.northstar_id
+	FROM 
+		(SELECT 
+			oc.device_id,
+			oc.northstar_id,
+			ROW_NUMBER() OVER (PARTITION BY oc.device_id ORDER BY oc.occurances DESC) AS ord 
+		FROM 
+			(SELECT DISTINCT 
+				pec.device_id,
+				pec.northstar_id,
+				count(*) AS occurances
+			FROM {{ ref('phoenix_events_combined') }} pec  
+			WHERE pec.northstar_id IS NOT NULL
+			GROUP BY pec.device_id, pec.northstar_id) oc
+			) ranked
+	WHERE ranked.ord=1
+)
+,
+nsid_less AS (
+	SELECT 
+		pec.device_id,
+		min(pec.event_datetime) AS journey_begin_ts,
+		max(
+			CASE 
+				WHEN pec.event_name IN 
+					('visit','view','phoenix_clicked_signup',
+					'phoenix_clicked_voter_registration_action') 
+				THEN 1 ELSE 0 END
+			) AS page_visit,
+		max(
+			CASE 
+				WHEN pec.event_name='phoenix_clicked_signup' 
+				THEN 1 ELSE 0 END
+			) AS click_join_us,
+		max(
+			CASE 
+				WHEN pec.northstar_id IS NOT NULL 
+				THEN 1 ELSE 0 END
+			) AS authenticated,
+		max(
+			CASE 
+				WHEN pec.event_name='phoenix_clicked_voter_registration_action' 
+				THEN 1 ELSE 0 END
+			) AS click_start_registration,
+		max(
+			CASE 
+				WHEN rtv.post_id IS NOT NULL 
+				THEN 1 ELSE 0 END
+			) AS clicked_get_started,
+		max(
+			CASE 
+				WHEN reg.northstar_id IS NOT NULL 
+				THEN 1 ELSE 0 END
+			) AS registered,
+		max(
+			CASE 
+				WHEN pec.event_name='phoenix_clicked_copy_to_clipboard' 
+				THEN 1 ELSE 0 END
+			) AS click_copy_link,
+		max(
+			CASE 
+				WHEN pec.event_name IN 
+					('phoenix_clicked_share_action_facebook','phoenix_clicked_share_email',
+					'phoenix_clicked_share_facebook_messenger','phoenix_clicked_share_twitter')
+				THEN 1 ELSE 0 END
+			) AS clicked_any_share,
+		max(
+			CASE 
+				WHEN pec.event_name='phoenix_clicked_share_action_facebook' 
+				THEN 1 ELSE 0 END
+			) AS clicked_share_fb,
+		max(
+			CASE 
+				WHEN pec.event_name='phoenix_clicked_share_email' 
+				THEN 1 ELSE 0 END
+			) AS clicked_share_email ,
+		max(
+			CASE 
+				WHEN pec.event_name='phoenix_clicked_share_facebook_messenger' 
+				THEN 1 ELSE 0 END
+			) AS clicked_share_fb_msgr,
+		max(
+			CASE 
+				WHEN pec.event_name='phoenix_clicked_share_twitter' 
+				THEN 1 ELSE 0 END
+			) AS clicked_share_twitter
+	FROM {{ ref('phoenix_events_combined') }} pec 
+	LEFT JOIN 
+		(SELECT 
+			r.northstar_id
+		FROM {{ ref('reportbacks') }} r 
+		LEFT JOIN {{ ref('rock_the_vote') }} rock 
+			ON rock.post_id = r.post_id 
+		WHERE 
+			r.post_bucket = 'voter_registrations'
+			AND rock.tracking_source ILIKE '%LYVCaffirmation%'
+			) reg 
+			ON reg.northstar_id = pec.northstar_id 
+	LEFT JOIN {{ ref('posts') }} po ON po.northstar_id=pec.northstar_id
+	LEFT JOIN {{ ref('rock_the_vote') }} rtv ON rtv.post_id=po.id AND rtv.status IS NOT NULL 
+	LEFT JOIN best_nsid ON best_nsid.device_id=pec.device_id 
+	WHERE 
+		pec.campaign_name = 'online-registration-drive'
+		AND pec.event_name IN (
+			'phoenix_clicked_copy_to_clipboard',
+			'phoenix_clicked_share_action_facebook',
+			'phoenix_clicked_share_email',
+			'phoenix_clicked_share_facebook_messenger',
+			'phoenix_clicked_share_twitter',
+			'phoenix_clicked_signup',
+			'phoenix_clicked_voter_registration_action',
+			'phoenix_opened_modal',
+			'visit',
+			'view'
+		)
+	GROUP BY pec.device_id
+	HAVING max(CASE WHEN pec.event_name IN 
+		('visit','view','phoenix_clicked_signup','phoenix_clicked_voter_registration_action') 
+			THEN 1 ELSE 0 END)=1
+	)		
+SELECT 
+	nsid_less.*,
+	best_nsid.northstar_id
+FROM nsid_less
+LEFT JOIN best_nsid ON nsid_less.device_id=best_nsid.device_id

--- a/quasar/dbt/models/user_journey/ovrd_recipient_funnel.sql
+++ b/quasar/dbt/models/user_journey/ovrd_recipient_funnel.sql
@@ -1,0 +1,18 @@
+SELECT 
+	po.northstar_id,
+	min(rtv.started_registration) AS journey_begin_ts,
+	max(
+		CASE 
+			WHEN rtv.status IS NOT NULL THEN 1 ELSE 0 END
+	) AS clicked_get_started,
+	max(
+		CASE 
+			WHEN rb.northstar_id IS NOT NULL THEN 1 ELSE 0 END 
+	) AS completed_registration
+FROM {{ ref('rock_the_vote') }} rtv 
+LEFT JOIN {{ ref('posts') }} po ON rtv.post_id=po.id
+LEFT JOIN {{ ref('reportbacks') }} rb ON rtv.post_id=rb.post_id AND rb.post_bucket = 'voter_registrations'
+WHERE 
+	rtv.tracking_source ILIKE '%referral=true%'
+	AND rtv.started_registration >= '2018-01-01'
+GROUP BY po.northstar_id

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = convert_deps_to_pip(pfile['packages'], r=False)
 
 setup(
     name="quasar",
-    version="2020.3.23.0",
+    version="2020.3.26.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
This PR adds the `ovrd_recipient_funnel` and `ovrd_creator_funnel` models to DBT.
 
#### Where should the reviewer start?
#### How should this be manually tested?
I've tested running these against the Quasar Prod Dump schema in QA. You can find the tables in `quasar_prod_dump.public`
```
dbt run -m user_journey --exclude user_journey.device_northstar --profile qa_prod --target qa_prod
Running with dbt=0.14.1
Found 36 models, 124 tests, 2 snapshots, 0 analyses, 117 macros, 0 operations, 0 seed files, 1 source

16:03:35 | Concurrency: 1 threads (target='qa_prod')
16:03:35 |
16:03:35 | 1 of 2 START table model public.ovrd_creator_funnel.................. [RUN]
16:06:56 | 1 of 2 OK created table model public.ovrd_creator_funnel............. [SELECT 168786 in 201.18s]
16:06:56 | 2 of 2 START table model public.ovrd_recipient_funnel................ [RUN]
16:06:57 | 2 of 2 OK created table model public.ovrd_recipient_funnel........... [SELECT 4536 in 0.75s]
16:06:57 |
16:06:57 | Finished running 2 table models in 203.18s.

Completed successfully
```
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/n/projects/2076969/stories/171991204
#### Screenshots (if appropriate)
#### Questions:
