### PR TITLE
Adding a doc block for months_since_created to fix breaking jobs

### DIFF
--- a/quasar/dbt/models/schema.md
+++ b/quasar/dbt/models/schema.md
@@ -647,6 +647,10 @@ Email subscription topics correspond to categories in CIO in which the user is i
 Whether we've paused sending sms messages to the user.
 {% enddocs %}
 
+{% docs months_since_created %}
+How many months since the user was created
+{% enddocs %}
+
 
 
 


### PR DESCRIPTION
#### What's this PR do?
This adds a doc block for `months_since_created` to fix jobs that are breaking in QA because that documentation is missing.

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/n/projects/2076969/stories/172217283
#### Screenshots (if appropriate)
#### Questions:
