### PR TITLE
Add vr source to posts

### DIFF
--- a/quasar/dbt/models/campaign_activity/posts.sql
+++ b/quasar/dbt/models/campaign_activity/posts.sql
@@ -50,7 +50,9 @@ SELECT
 	    ELSE NULL END AS num_participants,
 	a.civic_action,
 	a.scholarship_entry,
-	pd.school_id
+	pd.school_id,
+	split_part(substring(rtv.tracking_source from 'source\:(.+)'), ',', 1) AS vr_source,
+	split_part(substring(rtv.tracking_source from 'source_details\:(.+)'), ',', 1) AS vr_source_details
 FROM {{ env_var('FT_ROGUE') }}.posts pd
 INNER JOIN {{ ref('signups') }} s
 	ON pd.signup_id = s.id

--- a/quasar/dbt/models/campaign_activity/reportbacks.sql
+++ b/quasar/dbt/models/campaign_activity/reportbacks.sql
@@ -15,6 +15,8 @@ SELECT
     pd.scholarship_entry,
     pd.location,
     pd.postal_code,
+    pd.vr_source,
+    pd.vr_source_details,
     CASE
         WHEN (pd.post_class ilike '%vote%' AND pd.status = 'confirmed')
         THEN 'self-reported registrations'


### PR DESCRIPTION
#### What's this PR do?
* parses out voter reg source and source details from rock the vote tracking source into posts and reportbacks
#### Where should the reviewer start?
* posts.sql and reportbacks.sql
#### How should this be manually tested?
* run in QA
#### Any background context you want to provide?
* After corresponding looker changes, this will allow end users to split on source and source details in views of voter registrations
#### What are the relevant tickets?
* https://www.pivotaltracker.com/story/show/171891435
