### PR TITLE
Adding Contentful ID to users table to connect to contentful metadata

### DIFF
--- a/quasar/dbt/models/users_table/users.sql
+++ b/quasar/dbt/models/users_table/users.sql
@@ -30,6 +30,7 @@ SELECT
 	substring(u.source_detail from '(?<=utm_medium\:)(\w*)') AS utm_medium,
 	substring(u.source_detail from '(?<=utm_source\:)(\w*)') AS utm_source,
 	substring(u.source_detail from '(?<=utm_campaign\:)(\w*)') AS utm_campaign,
+	substring(u.source_detail from '(?<=contentful_id\:)(\w*)') AS contentful_id,
 	(u.feature_flags #>> '{badges}')::boolean as badges,
 	(u.feature_flags #>> '{refer-friends}')::boolean as refer_friends,
 	(u.feature_flags #>> '{refer-friends-scholarship}')::boolean as refer_friends_scholarship,


### PR DESCRIPTION
#### What's this PR do?
This PR pulls the Contentful ID from the `source_details` field in the users table so that we can link the new `contentful_metadata` table and make it easier to filter by campaign name. We could use a `LIKE` to join the tables, but that would interfere with indexing, so I'd like to avoid that.

Running this from my local to QA took 6.5 mins, so it shouldn't affect the users' table rebuild times.
#### Where should the reviewer start?
#### How should this be manually tested?
Here's a sample explore in QA that mimics the process Andrew uses, but it filters by title https://dsdata.looker.com/explore/blade_qa/user_activity?qid=Q2b48swUYLIIQvcvGUxTVf&toggle=fil

#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/n/projects/2076969/stories/171479610
#### Screenshots (if appropriate)
#### Questions:
