### PR TITLE
Adding device_campaign to campaign_activity model

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -143,6 +143,13 @@ models:
            - "CREATE INDEX IF NOT EXISTS reportbacks_i ON {{ this }}(post_created_at, campaign_id, post_class, reportback_volume)"
            - "GRANT SELECT ON {{ this }} TO dsanalyst"
            - "GRANT SELECT ON {{ this }} TO looker"
+        device_campaign:
+          alias: device_campaign
+          materialized: table
+          post-hook:
+            - "CREATE INDEX ON {{ this }}(device_id)"
+            - "GRANT SELECT ON {{ this }} TO dsanalyst"
+            - "GRANT SELECT ON {{ this }} TO looker"
       users_table:
         cio_latest_status:
           alias: cio_latest_status
@@ -237,7 +244,7 @@ models:
            - "CREATE INDEX IF NOT EXISTS email_subscription_topics_i ON {{ this }}(topic_subscribed_at, northstar_id)"
            - "GRANT SELECT ON {{ this }} TO dsanalyst"
            - "GRANT SELECT ON {{ this }} TO looker"
-      user_journey:
+      user_journey: 
         device_northstar:
           alias: device_northstar
           materialized: table

--- a/quasar/dbt/models/campaign_activity/device_campaign.sql
+++ b/quasar/dbt/models/campaign_activity/device_campaign.sql
@@ -1,0 +1,51 @@
+WITH device_campaign_session_ref AS
+  (SELECT dc.device_id,
+          dc.campaign_id,
+          dc.session_id,
+          dc.min_view_datetime,
+          CASE
+              WHEN s.session_referrer_host='' THEN NULL
+              ELSE s.session_referrer_host
+          END AS session_referrer_host,
+          s.session_utm_source,
+          s.session_utm_campaign,
+          dc.min_intent_datetime
+   FROM
+     (--was the device_campaign_session table
+ WITH device_campaign_all AS
+        (SELECT device_id,
+                campaign_id,
+                event_name,
+                event_datetime
+         FROM public.phoenix_events_combined
+         WHERE campaign_id IS NOT NULL ),
+      device_campaign_dates AS
+        (SELECT device_id,
+                campaign_id,
+                min(event_datetime) AS min_view_datetime,
+                min(CASE
+                        WHEN event_name='phoenix_clicked_signup' THEN event_datetime
+                    END) AS min_intent_datetime
+         FROM device_campaign_all
+         GROUP BY 1,
+                  2) SELECT DISTINCT d.device_id,
+                                     d.campaign_id,
+                                     e.session_id,
+                                     d.min_view_datetime,
+                                     d.min_intent_datetime
+      FROM device_campaign_dates d
+      JOIN public.phoenix_events_combined e ON (d.device_id=e.device_id
+                                                AND d.campaign_id=e.campaign_id
+                                                AND d.min_view_datetime=e.event_datetime)) dc --Join w session table to get referring sources
+
+   JOIN public.phoenix_sessions_combined s ON (dc.session_id=s.session_id))
+SELECT device_id,
+       campaign_id,
+       session_id,
+       min_view_datetime,
+       session_referrer_host,
+       session_utm_source,
+       session_utm_campaign,
+       min_intent_datetime
+FROM device_campaign_session_ref
+


### PR DESCRIPTION
#### What's this PR do?
This PR adds the `device_campaign` SQL to the `campaign_activity` model. The SQL in the ticket uses an intermediate table, but this PR removes the intermediate table and instead uses a subquery. 
#### Where should the reviewer start?
#### How should this be manually tested?
I've tested it manually from my local to QA:
```
└─▪ dbt run -m user_journey.device_campaign --profile qa --target qa
Running with dbt=0.14.4
Found 38 models, 135 tests, 2 snapshots, 0 analyses, 117 macros, 0 operations, 0 seed files, 3 sources

14:34:42 | Concurrency: 1 threads (target='qa')
14:34:42 |
14:34:42 | 1 of 1 START table model public.device_campaign...................... [RUN]
15:31:07 | 1 of 1 OK created table model public.device_campaign................. [SELECT 6058095 in 3385.68s]
15:31:08 |
15:31:08 | Finished running 1 table model in 3386.88s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/n/projects/2076969/stories/172238878
#### Screenshots (if appropriate)
#### Questions:
