### PR TITLE
Updates campaign_info model with new metadata provided by Eri

### DIFF
--- a/quasar/dbt/models/campaign_info/campaign_info.sql
+++ b/quasar/dbt/models/campaign_info/campaign_info.sql
@@ -1,57 +1,50 @@
-with
+WITH
 --Campaigns with Online/Offline Post Components
-campaign_online as (
-  select campaign_id, count(distinct online) as online_count, min(case when online=true then 'Online' else 'Offline' end) as min_online
-  from {{ ref('post_actions') }}
-  group by 1
-)
-,
-campaign_online_combo as (
-    select campaign_id, case when online_count>1 then 'Both' else min_online end as online_offline
-    from campaign_online
-)
-,
+campaign_online AS (
+  SELECT campaign_id, count(DISTINCT online) AS online_count, min(CASE WHEN online=true THEN 'Online' ELSE 'Offline' END) AS min_online
+  FROM {{ ref('post_actions') }}
+  GROUP BY 1
+),
+campaign_online_combo AS (
+    SELECT campaign_id, CASE WHEN online_count>1 THEN 'Both' ELSE min_online END AS online_offline
+    FROM campaign_online
+),
 --Campaigns and Action Types
-campaign_action as (
-  select campaign_id, action_type
-  from {{ ref('post_actions') }}
-  where action_type is not null and action_type<>''
-  group by 1, 2
-)
-,
+campaign_action AS (
+  SELECT campaign_id, action_type
+  FROM {{ ref('post_actions') }}
+  WHERE action_type IS NOT null AND action_type<>''
+  GROUP BY 1, 2
+),
 --Campaigns and Action Types Combined
-campaign_action_combo as (
-    select campaign_id, string_agg(action_type, ' , ' order by action_type) as action_types
-    from campaign_action
-    group by 1
-)
-,
+campaign_action_combo AS (
+    SELECT campaign_id, string_agg(action_type, ' , ' ORDER BY action_type) AS action_types
+    FROM campaign_action
+    GROUP BY 1
+),
 -- Campaigns and Scholarship
-campaign_scholarship as (
-  select campaign_id, count(case when scholarship_entry=true then 1 end) as scholarship
-  from {{ ref('post_actions') }}
-  group by 1
-)
-,
+campaign_scholarship AS (
+  SELECT campaign_id, count(CASE WHEN scholarship_entry=true THEN 1 END) AS scholarship
+  FROM {{ ref('post_actions') }}
+  GROUP BY 1
+),
 -- Campaigns and Scholarship Combined
-campaign_scholarship_combo as (
-    select campaign_id, (case when scholarship>0 then 'Scholarship' else 'Not Scholarship' end) as scholarship
-    from campaign_scholarship
-)
-,
+campaign_scholarship_combo AS (
+    SELECT campaign_id, (CASE WHEN scholarship>0 THEN 'Scholarship' ELSE 'Not Scholarship' END) AS scholarship
+    FROM campaign_scholarship
+),
 --Campaigns and Action Types
-campaign_post_type as (
-  select campaign_id, post_type
-  from {{ ref('post_actions') }}
-  where post_type is not null and post_type<>''
-  group by 1, 2
-)
-,
+campaign_post_type AS (
+  SELECT campaign_id, post_type
+  FROM {{ ref('post_actions') }}
+  WHERE post_type IS NOT null AND post_type<>''
+  GROUP BY 1, 2
+),
 --Campaigns and Action Types Combined
-campaign_post_type_combo as (
-    select campaign_id, string_agg(post_type, ' , ' order by post_type) as post_types
-    from campaign_post_type
-    group by 1
+campaign_post_type_combo AS (
+    SELECT campaign_id, string_agg(post_type, ' , ' ORDER BY post_type) AS post_types
+    FROM campaign_post_type
+    GROUP BY 1
 )
 SELECT 
 	c.id AS campaign_id,
@@ -64,15 +57,15 @@ SELECT
 	COALESCE(i.campaign_node_id, c.id) AS campaign_node_id,
 	i.campaign_node_id_title,
 	i.campaign_run_id_title,
-	case when i.campaign_action_type = '' then null else i.campaign_action_type end as campaign_action_type,
+	CASE WHEN i.campaign_action_type = '' THEN null ELSE i.campaign_action_type END AS campaign_action_type,
 	COALESCE(
-		case when c.cause = '' then null else c.cause end, 
-		case when i.campaign_cause_type = '' then null else i.campaign_cause_type end
+		CASE WHEN c.cause = '' THEN null ELSE c.cause END,
+		CASE WHEN i.campaign_cause_type = '' THEN null ELSE i.campaign_cause_type END
 	) AS campaign_cause_type,
 	i.campaign_noun,
 	i.campaign_verb,
 	i.campaign_cta,
-	case when a.action_types = '' then null else a.action_types end as action_types,
+	CASE WHEN a.action_types = '' THEN null ELSE a.action_types END AS action_types,
 	o.online_offline,
 	s.scholarship,
 	p.post_types

--- a/quasar/dbt/models/campaign_info/campaign_info.sql
+++ b/quasar/dbt/models/campaign_info/campaign_info.sql
@@ -21,7 +21,7 @@ campaign_action as (
 ,
 --Campaigns and Action Types Combined
 campaign_action_combo as (
-    select campaign_id, string_agg(action_type, ' / ' order by action_type) as action_types
+    select campaign_id, string_agg(action_type, ' , ' order by action_type) as action_types
     from campaign_action
     group by 1
 )
@@ -49,7 +49,7 @@ campaign_post_type as (
 ,
 --Campaigns and Action Types Combined
 campaign_post_type_combo as (
-    select campaign_id, string_agg(post_type, ' / ' order by post_type) as post_types
+    select campaign_id, string_agg(post_type, ' , ' order by post_type) as post_types
     from campaign_post_type
     group by 1
 )

--- a/quasar/dbt/models/campaign_info/campaign_info.sql
+++ b/quasar/dbt/models/campaign_info/campaign_info.sql
@@ -1,3 +1,58 @@
+with
+--Campaigns with Online/Offline Post Components
+campaign_online as (
+  select campaign_id, count(distinct online) as online_count, min(case when online=true then 'Online' else 'Offline' end) as min_online
+  from {{ ref('post_actions') }}
+  group by 1
+)
+,
+campaign_online_combo as (
+    select campaign_id, case when online_count>1 then 'Both' else min_online end as online_offline
+    from campaign_online
+)
+,
+--Campaigns and Action Types
+campaign_action as (
+  select campaign_id, action_type
+  from {{ ref('post_actions') }}
+  where action_type is not null and action_type<>''
+  group by 1, 2
+)
+,
+--Campaigns and Action Types Combined
+campaign_action_combo as (
+    select campaign_id, string_agg(action_type, ' / ' order by action_type) as action_types
+    from campaign_action
+    group by 1
+)
+,
+-- Campaigns and Scholarship
+campaign_scholarship as (
+  select campaign_id, count(case when scholarship_entry=true then 1 end) as scholarship
+  from {{ ref('post_actions') }}
+  group by 1
+)
+,
+-- Campaigns and Scholarship Combined
+campaign_scholarship_combo as (
+    select campaign_id, (case when scholarship>0 then 'Scholarship' else 'Not Scholarship' end) as scholarship
+    from campaign_scholarship
+)
+,
+--Campaigns and Action Types
+campaign_post_type as (
+  select campaign_id, post_type
+  from {{ ref('post_actions') }}
+  where post_type is not null and post_type<>''
+  group by 1, 2
+)
+,
+--Campaigns and Action Types Combined
+campaign_post_type_combo as (
+    select campaign_id, string_agg(post_type, ' / ' order by post_type) as post_types
+    from campaign_post_type
+    group by 1
+)
 SELECT 
 	c.id AS campaign_id,
 	c.campaign_run_id,
@@ -9,11 +64,22 @@ SELECT
 	COALESCE(i.campaign_node_id, c.id) AS campaign_node_id,
 	i.campaign_node_id_title,
 	i.campaign_run_id_title,
-	i.campaign_action_type,
-	COALESCE(c.cause, i.campaign_cause_type) AS campaign_cause_type,
+	case when i.campaign_action_type = '' then null else i.campaign_action_type end as campaign_action_type,
+	COALESCE(
+		case when c.cause = '' then null else c.cause end, 
+		case when i.campaign_cause_type = '' then null else i.campaign_cause_type end
+	) AS campaign_cause_type,
 	i.campaign_noun,
 	i.campaign_verb,
-	i.campaign_cta
+	i.campaign_cta,
+	case when a.action_types = '' then null else a.action_types end as action_types,
+	o.online_offline,
+	s.scholarship,
+	p.post_types
 FROM {{ env_var('FT_ROGUE') }}.campaigns c
-LEFT JOIN {{ env_var('CAMPAIGN_INFO_ASHES_SNAPSHOT') }}  i ON i.campaign_run_id = c.campaign_run_id
-WHERE i.campaign_language = 'en' OR i.campaign_language IS NULL
+LEFT JOIN {{ env_var('CAMPAIGN_INFO_ASHES_SNAPSHOT') }} i ON i.campaign_run_id = c.campaign_run_id
+LEFT JOIN campaign_action_combo a on c.id = a.campaign_id
+LEFT JOIN campaign_online_combo o on c.id = o.campaign_id
+LEFT JOIN campaign_scholarship_combo s on c.id = s.campaign_id
+LEFT JOIN campaign_post_type_combo p on c.id = p.campaign_id
+WHERE i.campaign_language = 'en' OR i.campaign_language IS null


### PR DESCRIPTION
#### What's this PR do?
It merges the updates to the Campaign Info model provided by @eriqa. It adds the columns:
- `action_types`
- `post_types`
- `online_offline`
- `scholarship`
- `post_types`

Tested manually against QA:
```
rpacas@Rafaels-MBP
 in   ~/Desktop/repos/q/quasar/dbt (campaign-info-metadata-updates) $ dbt run -m campaign_info --profile qa
Running with dbt=0.14.2
Found 37 models, 135 tests, 2 snapshots, 0 analyses, 117 macros, 0 operations, 0 seed files, 3 sources

13:24:42 | Concurrency: 4 threads (target='default')
13:24:42 | 
13:24:42 | 1 of 2 START table model public.campaign_info........................ [RUN]
13:24:42 | 2 of 2 START table model public.campaign_info_international.......... [RUN]
13:24:45 | 1 of 2 OK created table model public.campaign_info................... [SELECT 736 in 1.83s]
13:24:45 | 2 of 2 OK created table model public.campaign_info_international..... [SELECT 177 in 2.22s]
13:24:45 | 
13:24:45 | Finished running 2 table models in 4.66s.

Completed successfully

Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
```
#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/172238840


