### PR TITLE
pull voter reg source=ads directly from tracking source

### DIFF
--- a/quasar/dbt/models/campaign_activity/posts.sql
+++ b/quasar/dbt/models/campaign_activity/posts.sql
@@ -51,7 +51,10 @@ SELECT
 	a.civic_action,
 	a.scholarship_entry,
 	pd.school_id,
-	split_part(substring(rtv.tracking_source from 'source\:(.+)'), ',', 1) AS vr_source,
+	CASE 
+		WHEN rtv.tracking_source='ads' THEN 'ads'
+		ELSE split_part(substring(rtv.tracking_source from 'source\:(.+)'), ',', 1) 
+		END AS vr_source,
 	split_part(substring(rtv.tracking_source from 'source_details\:(.+)'), ',', 1) AS vr_source_details
 FROM {{ env_var('FT_ROGUE') }}.posts pd
 INNER JOIN {{ ref('signups') }} s


### PR DESCRIPTION
#### What's this PR do?
* Updated the voter reg source tracking logic to directly pull out where source = ads
#### Where should the reviewer start?
* posts.sql
#### How should this be manually tested?
* Run in QA
#### Any background context you want to provide?
* Allows for end users to do analysis in Looker split on source/source_details 
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/171891435
