### PR TITLE
Adds new user_rb_summary model provided by Eri

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -185,6 +185,13 @@ models:
            - "CREATE INDEX IF NOT EXISTS most_recent_all_actions_i ON {{ this }}(most_recent_all_actions)"
            - "GRANT SELECT ON {{ this }} TO dsanalyst"
            - "GRANT SELECT ON {{ this }} TO looker"
+        user_rb_summary:
+          alias: user_rb_summary
+          materialized: table
+          post-hook:
+           - "CREATE UNIQUE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_unique_i ON {{ this }}(signup_id)"
+           - "GRANT SELECT ON {{ this }} TO dsanalyst"
+           - "GRANT SELECT ON {{ this }} TO looker"
       campaign_info:
         campaign_info:
           alias: campaign_info
@@ -321,4 +328,3 @@ models:
             - "CREATE INDEX ON {{ this }}(northstar_id, device_id, journey_begin_ts)"
             - "GRANT SELECT ON {{ this }} to dsanalyst"
             - "GRANT SELECT ON {{ this }} to looker"          
-

--- a/quasar/dbt/models/schema.md
+++ b/quasar/dbt/models/schema.md
@@ -23,6 +23,14 @@ ID of the broadcast that generated the shortened URL
 Source of the URL (e.g. SMS, web), origin of the post (e.g. phoenix-web, phoenix-ashes, sms), or source where user was acquired. (e.g. sms, phoenix-next)
 {% enddocs %}
 
+{% docs post_sources %}
+Sources of the Posts (e.g. sms, web)
+{% enddocs %}
+
+{% docs post_types %}
+Types of Posts (e.g. photo, phone-call, share-social, text, voter-reg, email)
+{% enddocs %}
+
 {% docs interaction_type %}
 How the user interacted with the link (e.g. preview, click)
 {% enddocs %}
@@ -64,7 +72,7 @@ Text of the post (e.g. "Zoo animals and a super hero trying to help too!")
 {% enddocs %}
 
 {% docs signup_id %}
-Unique identifier for the signup 
+Unique identifier for the signup
 {% enddocs %}
 
 {% docs post_class %}
@@ -76,7 +84,7 @@ Whether the post has been accepted to be displayed to the public on the website
 {% enddocs %}
 
 {% docs action_id %}
-Internal identifier of the action 
+Internal identifier of the action
 {% enddocs %}
 
 {% docs location %}
@@ -159,6 +167,10 @@ Title of the campaign run
 Campaign action type (eg. Make Something, Share Something)
 {% enddocs %}
 
+{% docs action_types %}
+Types of actions of the Posts (e.g. attend-event, share-something, make-something, collect-something, contact-decisionmaker, donate-something, host-event, have-a-conversation, flag-content, sign-petition, submit-tip, other)
+{% enddocs %}
+
 {% docs campaign_cause_type %}
 Campaign cause type (eg. Mental Health, Education)
 {% enddocs %}
@@ -200,7 +212,7 @@ Channel for the user's action. Depends on the source of the action. (e.g. web, s
 {% enddocs %}
 
 {% docs first_action_month %}
-Month during which the user took their first action. 
+Month during which the user took their first action.
 {% enddocs %}
 
 {% docs event_id %}
@@ -377,6 +389,10 @@ Type of action the user took. (e.g. share-something, donate-something)
 
 {% docs online %}
 Whether the action is a online as opposed to IRL.
+{% enddocs %}
+
+{% docs online_offline %}
+Whether the action is online or offline (IRL).
 {% enddocs %}
 
 {% docs time_commitment %}
@@ -790,5 +806,3 @@ The most recent time the user registered to vote
 {% docs submit_quiz_register_affirmation %}
 Submitted the quiz, and then registered to vote
 {% enddocs %}
-
-

--- a/quasar/dbt/models/user_activity/schema.yml
+++ b/quasar/dbt/models/user_activity/schema.yml
@@ -71,3 +71,27 @@ models:
         - name: voter_reg_acquisition
           description: '{{ doc("voter_reg_acquisition") }}'
 
+  - name: user_rb_summary
+    description: Table that aggregates traits of multiple Report-Backs per SignUp into a single row.
+
+    columns:
+        - name: signup_id
+          description: '{{ doc("signup_id") }}'
+
+        - name: num_rbs
+          description: '{{ doc("num_rbs") }}'
+
+        - name: first_rb
+          description: '{{ doc("first_rb") }}'
+
+        - name: post_sources
+          description: '{{ doc("post_sources") }}'
+
+        - name: post_types
+          description: '{{ doc("post_types") }}'
+
+        - name: action_types
+          description: '{{ doc("action_types") }}'
+
+        - name: online_offline
+          description: '{{ doc("online_offline") }}'

--- a/quasar/dbt/models/user_activity/user_rb_summary.sql
+++ b/quasar/dbt/models/user_activity/user_rb_summary.sql
@@ -1,0 +1,159 @@
+--user_rb_summary aggregates traits of multiple Report-Backs per SignUp into a single row
+--so they can be analized as a single fact of reporting back
+--user_rb_summary is used in the final table which will be referenced by Looker in view:
+--campaign_funnel
+--which is used to generate dashboards:
+--Campaign Journey Dashboard (https://dsdata.looker.com/dashboards/183)
+--Marketing Journey Dashboard (https://dsdata.looker.com/dashboards/184)
+
+--RBs get info
+WITH rbs_all AS (
+	SELECT
+		r.signup_id,
+		r.post_id,
+		r.post_created_at,
+		r.post_type,
+		r.post_source_bucket,
+		CASE
+			WHEN pa.action_type = ''
+			OR pa.action_type = ' ' THEN NULL
+			ELSE pa.action_type
+		END AS action_type,
+		CASE
+			WHEN pa.online = TRUE THEN 'Online'
+			WHEN pa.online = FALSE THEN 'Offline'
+		END AS online_offline,
+		CASE
+			WHEN pa.scholarship_entry = TRUE THEN 'Scholarship'
+			WHEN pa.scholarship_entry = FALSE THEN 'Not Scholarship'
+		END AS scholarship
+	FROM
+		{{ ref('reportbacks') }} r
+		JOIN {{ ref('posts') }} p ON (r.post_id = p.id)
+		JOIN {{ ref('post_actions') }} pa ON (p.action_id = pa.id)
+	WHERE
+		r.signup_id > 0
+	ORDER BY
+		r.signup_id
+),
+--RBs unique post types
+rbs_post_types AS (
+	SELECT
+		DISTINCT signup_id,
+		post_type
+	FROM
+		rbs_all
+),
+--RBs agg post types
+rbs_post_types_agg AS (
+	SELECT
+		signup_id,
+		string_agg(
+			post_type,
+			' , '
+			ORDER BY
+				post_type DESC
+		) AS post_types
+	FROM
+		rbs_post_types
+	GROUP BY
+		signup_id
+),
+--RBs unique post sources
+rbs_post_sources AS (
+	SELECT
+		DISTINCT signup_id,
+		post_source_bucket
+	FROM
+		rbs_all
+),
+--RBs agg post types
+rbs_post_sources_agg AS (
+	SELECT
+		signup_id,
+		string_agg(
+			post_source_bucket,
+			' , '
+			ORDER BY
+				post_source_bucket DESC
+		) AS post_sources
+	FROM
+		rbs_post_sources
+	GROUP BY
+		signup_id
+),
+--RBs unique action types
+rbs_action_types AS (
+	SELECT
+		DISTINCT signup_id,
+		action_type
+	FROM
+		rbs_all
+	WHERE
+		action_type IS NOT NULL
+),
+--RBs agg action types
+rbs_action_types_agg AS (
+	SELECT
+		signup_id,
+		string_agg(
+			action_type,
+			' , '
+			ORDER BY
+				action_type DESC
+		) AS action_types
+	FROM
+		rbs_action_types
+	GROUP BY
+		signup_id
+),
+--RBs unique online/offline
+rbs_online_offline AS (
+	SELECT
+		DISTINCT signup_id,
+		online_offline
+	FROM
+		rbs_all
+	WHERE
+		online_offline IS NOT NULL
+),
+--RBs agg action types
+rbs_online_offline_agg AS (
+	SELECT
+		signup_id,
+		string_agg(
+			online_offline,
+			' , '
+			ORDER BY
+				online_offline DESC
+		) AS online_offline
+	FROM
+		rbs_online_offline
+	GROUP BY
+		signup_id
+),
+--RBs get summarized
+rb_summ AS (
+	SELECT
+		r.signup_id,
+		count(r.post_id) AS num_rbs,
+		min(r.post_created_at) AS first_rb
+	FROM
+		rbs_all r
+	GROUP BY
+		r.signup_id
+)
+SELECT
+	r.signup_id,
+	r.num_rbs,
+	r.first_rb,
+	rs.post_sources,
+	rp.post_types,
+	ra.action_types,
+	ro.online_offline
+FROM
+	rb_summ r
+	LEFT JOIN rbs_post_types_agg rp ON (r.signup_id = rp.signup_id)
+	LEFT JOIN rbs_post_sources_agg rs ON (r.signup_id = rs.signup_id)
+	LEFT JOIN rbs_action_types_agg ra ON (r.signup_id = ra.signup_id)
+	LEFT JOIN rbs_online_offline_agg ro ON (r.signup_id = ro.signup_id)


### PR DESCRIPTION
#### What's this PR do?
- Adds new `user_rb_summary` model provided by @eriqa w/ minor edits.

Tested manually against QA:

```
 in   ~/Desktop/repos/q/quasar/dbt (user-reportback-summary-model) $ dbt run -m user_activity.user_rb_summary --profile qa
Running with dbt=0.14.2
Found 39 models, 135 tests, 2 snapshots, 0 analyses, 117 macros, 0 operations, 0 seed files, 3 sources

16:16:56 | Concurrency: 4 threads (target='default')
16:16:56 | 
16:16:56 | 1 of 1 START table model public.user_rb_summary...................... [RUN]
16:17:15 | 1 of 1 OK created table model public.user_rb_summary................. [SELECT 985892 in 18.28s]
16:17:15 | 
16:17:15 | Finished running 1 table model in 20.68s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/172238993

