### PR TITLE
Adds first_and_second_signups model provided by Eri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/run_results.json
 docs/catalog.json
 docs/graph.gpickle
 docs/compiled/
+.python-version

--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -150,6 +150,13 @@ models:
             - "CREATE INDEX ON {{ this }}(device_id)"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"
             - "GRANT SELECT ON {{ this }} TO looker"
+        first_and_second_signups:
+          alias: first_and_second_signups
+          materialized: table
+          post-hook:
+            - "CREATE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_northstar_id_idx ON {{ this }}(northstar_id)"
+            - "GRANT SELECT ON {{ this }} TO dsanalyst"
+            - "GRANT SELECT ON {{ this }} TO looker"
       users_table:
         cio_latest_status:
           alias: cio_latest_status

--- a/quasar/dbt/models/campaign_activity/first_and_second_signups.sql
+++ b/quasar/dbt/models/campaign_activity/first_and_second_signups.sql
@@ -232,9 +232,9 @@ SELECT
 FROM
     ns_signups ns1
     LEFT JOIN ns_signup_2 ns2 ON (ns1.northstar_id = ns2.northstar_id)
-    JOIN { { ref('campaign_info') } } c1 ON (ns1.campaign_id = c1.campaign_id :: text)
-    LEFT JOIN { { ref('campaign_info') } } c2 ON (ns2.campaign_id = c2.campaign_id :: text)
-    LEFT JOIN { { ref('user_rb_summary') } } r1 ON (ns1.signup_id = r1.signup_id)
-    LEFT JOIN { { ref('user_rb_summary') } } r2 ON (ns2.signup_id = r2.signup_id)
+    JOIN {{ ref('campaign_info') }} c1 ON (ns1.campaign_id = c1.campaign_id :: text)
+    LEFT JOIN {{ ref('campaign_info') }} c2 ON (ns2.campaign_id = c2.campaign_id :: text)
+    LEFT JOIN {{ ref('user_rb_summary') }} r1 ON (ns1.signup_id = r1.signup_id)
+    LEFT JOIN {{ ref('user_rb_summary') }} r2 ON (ns2.signup_id = r2.signup_id)
 WHERE
     ns1.nth_signup = 1

--- a/quasar/dbt/models/campaign_activity/first_and_second_signups.sql
+++ b/quasar/dbt/models/campaign_activity/first_and_second_signups.sql
@@ -1,0 +1,240 @@
+--first_and_second_signups is the final table referenced used by Looker in 3 views:
+--campaign_signups_1_and_2:
+--https://dsdata.looker.com/projects/blade/files/campaign_signups_1_and_2.view
+--channel_crossover:
+--https://dsdata.looker.com/projects/blade/files/channel_crossover.view.lkml
+--channel_crossover_campaigns:
+--https://dsdata.looker.com/projects/blade/files/channel_crossover_campaigns.view.lkml
+--which are used to generate dashboards:
+--https://dsdata.looker.com/dashboards/188 (Campaign Sign-Ups 1&2)
+--https://dsdata.looker.com/dashboards/208 (User Channel Crossover)
+--table first_and_second_signups bring signups 1 & 2 (of the same user) into a single row
+--along with previously generated campaign-level data ( campaign_info )
+--with the goal of comparing them to determine whether there are patterns
+--corresponding to better report-back rates
+
+WITH ns_signups AS (
+    SELECT
+        id AS signup_id,
+        northstar_id,
+        campaign_id,
+        source_bucket,
+        created_at,
+        rank() over(
+            PARTITION by northstar_id
+            ORDER BY
+                created_at
+        ) nth_signup
+    FROM
+        {{ ref('signups') }}
+),
+ns_signup_2 AS (
+    SELECT
+        *
+    FROM
+        ns_signups
+    WHERE
+        nth_signup = 2
+)
+SELECT
+    ns1.northstar_id,
+    ns1.campaign_id AS campaign_id_1,
+    ns2.campaign_id AS campaign_id_2,
+    ns1.signup_id AS signup_id_1,
+    ns2.signup_id AS signup_id_2,
+    --Sign-Up Source
+    ns1.source_bucket AS signup_source_bucket_1,
+    ns2.source_bucket AS signup_source_bucket_2,
+    CASE
+        WHEN NULLIF(ns1.source_bucket, '') IS NULL
+        AND NULLIF(ns2.source_bucket, '') IS NULL THEN 'Both are Unknown'
+        ELSE concat(
+            coalesce(NULLIF(ns1.source_bucket, ''), 'Unknown'),
+            ' / ',
+            coalesce(NULLIF(ns2.source_bucket, ''), 'Unknown')
+        )
+    END AS signup_source_bucket_pattern,
+    --Action Type from Campaign_Info table
+    c1.campaign_action_type AS campaign_action_type_1,
+    c2.campaign_action_type AS campaign_action_type_2,
+    CASE
+        WHEN NULLIF(c1.campaign_action_type, '') IS NULL
+        AND NULLIF(c2.campaign_action_type, '') IS NULL THEN 'Both are Unknown'
+        WHEN NULLIF(c1.campaign_action_type, '') IS NULL
+        OR NULLIF(c2.campaign_action_type, '') IS NULL THEN 'One is Unknown'
+        WHEN c1.campaign_action_type LIKE concat('%', c2.campaign_action_type, '%')
+        OR c2.campaign_action_type LIKE concat('%', c1.campaign_action_type, '%')
+        OR (
+            c1.campaign_action_type LIKE '%Donate Something%'
+            AND c2.campaign_action_type LIKE '%Donate Something%'
+        )
+        OR (
+            c1.campaign_action_type LIKE '%Make Something%'
+            AND c2.campaign_action_type LIKE '%Make Something%'
+        )
+        OR (
+            c1.campaign_action_type LIKE '%Share Something%'
+            AND c2.campaign_action_type LIKE '%Share Something%'
+        )
+        OR (
+            c1.campaign_action_type LIKE '%Take a Stand%'
+            AND c2.campaign_action_type LIKE '%Take a Stand%'
+        ) THEN 'Same'
+        ELSE 'Different'
+    END AS campaign_action_type_pattern,
+    --Action Type from Campaign_Info table
+    c1.campaign_cause_type AS campaign_cause_type_1,
+    c2.campaign_cause_type AS campaign_cause_type_2,
+    CASE
+        WHEN NULLIF(c1.campaign_cause_type, '') IS NULL
+        AND NULLIF(c2.campaign_cause_type, '') IS NULL THEN 'Both are Unknown'
+        WHEN NULLIF(c1.campaign_cause_type, '') IS NULL
+        OR NULLIF(c2.campaign_cause_type, '') IS NULL THEN 'One is Unknown'
+        WHEN c1.campaign_cause_type LIKE concat('%', c2.campaign_cause_type, '%')
+        OR c2.campaign_cause_type LIKE concat('%', c1.campaign_cause_type, '%') THEN 'Same'
+        ELSE 'Different'
+    END AS campaign_cause_type_pattern,
+    --Online/Offline from Campaign_Info table (derived from all RBs for each Campaign ID)
+    c1.online_offline AS campaign_online_offline_1,
+    c2.online_offline AS campaign_online_offline_2,
+    CASE
+        WHEN NULLIF(c1.online_offline, '') IS NULL
+        AND NULLIF(c2.online_offline, '') IS NULL THEN 'Both are Unknown'
+        WHEN c1.online_offline = c2.online_offline THEN concat('Both are ', c1.online_offline)
+        ELSE concat(
+            coalesce(c1.online_offline, 'Unknown'),
+            ' / ',
+            coalesce(c2.online_offline, 'Unknown')
+        )
+    END AS campaign_online_offline_pattern,
+    --Action Type from Campaign_Info table (derived from all RBs for each Campaign ID)
+    c1.action_types AS campaign_action_types_1,
+    c2.action_types AS campaign_action_types_2,
+    CASE
+        WHEN NULLIF(c1.action_types, '') IS NULL
+        AND NULLIF(c2.action_types, '') IS NULL THEN 'Both are Unknown'
+        WHEN NULLIF(c1.action_types, '') IS NULL
+        OR NULLIF(c2.action_types, '') IS NULL THEN 'One is Unknown'
+        WHEN c1.action_types LIKE concat('%', c2.action_types, '%')
+        OR c2.action_types LIKE concat('%', c1.action_types, '%') THEN 'Same'
+        ELSE 'Different'
+    END AS campaign_action_types_pattern,
+    --Scholarship from Campaign_Info table (derived from all RBs for each Campaign ID)
+    c1.scholarship AS campaign_scholarship_1,
+    c2.scholarship AS campaign_scholarship_2,
+    CASE
+        WHEN NULLIF(c1.scholarship, '') IS NULL
+        AND NULLIF(c2.scholarship, '') IS NULL THEN 'Both are Unknown'
+        WHEN c1.scholarship = c2.scholarship THEN concat('Both are ', c1.scholarship)
+        ELSE concat(
+            coalesce(c1.scholarship, 'Unknown'),
+            ' / ',
+            coalesce(c2.scholarship, 'Unknown')
+        )
+    END AS campaign_scholarship_pattern,
+    --Post Type from Campaign_Info table (derived from all RBs for each Campaign ID)
+    c1.post_types AS campaign_post_types_1,
+    c2.post_types AS campaign_post_types_2,
+    CASE
+        WHEN NULLIF(c1.post_types, '') IS NULL
+        AND NULLIF(c2.post_types, '') IS NULL THEN 'Both are Unknown'
+        WHEN NULLIF(c1.post_types, '') IS NULL
+        OR NULLIF(c2.post_types, '') IS NULL THEN 'One is Unknown'
+        WHEN c1.post_types LIKE concat('%', c2.post_types, '%')
+        OR c2.post_types LIKE concat('%', c1.post_types, '%') THEN 'Same'
+        ELSE 'Different'
+    END AS campaign_post_types_pattern,
+    --Report Backs from Signup 1 & 2 Report Backs
+    r1.num_rbs AS num_rbs_1,
+    r2.num_rbs AS num_rbs_2,
+    CASE
+        WHEN coalesce(r1.num_rbs, 0) = 0
+        AND coalesce(r2.num_rbs, 0) = 0 THEN 'No RB to Either SignUp'
+        WHEN coalesce(r1.num_rbs, 0) = 0 THEN 'No RB to SignUp 1'
+        WHEN coalesce(r2.num_rbs, 0) = 0 THEN 'No RB to SignUp 2'
+        WHEN r1.num_rbs > 0
+        AND r2.num_rbs > 0 THEN 'RB to Both SignUps'
+        ELSE '?'
+    END AS num_rbs_pattern,
+    --Report-Back Source
+    r1.post_sources AS rb_source_buckets_1,
+    r2.post_sources AS rb_source_buckets_2,
+    CASE
+        WHEN coalesce(r1.num_rbs, 0) = 0
+        AND coalesce(r2.num_rbs, 0) = 0 THEN 'No RB to Either SignUp'
+        WHEN coalesce(r1.num_rbs, 0) = 0 THEN concat(
+            'No RB',
+            ' / ',
+            coalesce(r2.post_sources, 'Unknown')
+        )
+        WHEN coalesce(r2.num_rbs, 0) = 0 THEN concat(
+            coalesce(r1.post_sources, 'Unknown'),
+            ' / ',
+            'No RB'
+        )
+        ELSE concat(
+            coalesce(r1.post_sources, 'Unknown'),
+            ' / ',
+            coalesce(r2.post_sources, 'Unknown')
+        )
+    END AS rb_source_buckets_pattern,
+    --Report Back Types from Signup 1 & 2 Report Backs
+    r1.post_types AS rb_post_types_1,
+    r2.post_types AS rb_post_types_2,
+    CASE
+        WHEN coalesce(r1.num_rbs, 0) = 0
+        AND coalesce(r2.num_rbs, 0) = 0 THEN 'No RB to Either SignUp'
+        WHEN coalesce(r1.num_rbs, 0) = 0 THEN 'No RB to SignUp 1'
+        WHEN coalesce(r2.num_rbs, 0) = 0 THEN 'No RB to SignUp 2'
+        WHEN coalesce(r1.post_types, '') = ''
+        AND coalesce(r2.post_types, '') = '' THEN 'Both RB Post Types are Unknown'
+        WHEN coalesce(r1.post_types, '') = '' THEN 'RB Post Type 1 is Unknown'
+        WHEN coalesce(r2.post_types, '') = '' THEN 'RB Post Type 2 is Unknown'
+        WHEN r1.post_types LIKE concat('%', r2.post_types, '%')
+        OR r2.post_types LIKE concat('%', r1.post_types, '%') THEN 'Same'
+        ELSE 'Different'
+    END AS rb_post_types_pattern,
+    --Report Back Online/Offline from Signup 1 & 2 Report Backs
+    r1.online_offline AS rb_online_offline_1,
+    r2.online_offline AS rb_online_offline_2,
+    CASE
+        WHEN coalesce(r1.num_rbs, 0) = 0
+        AND coalesce(r2.num_rbs, 0) = 0 THEN 'No RB to Either SignUp'
+        WHEN coalesce(r1.num_rbs, 0) = 0 THEN 'No RB to SignUp 1'
+        WHEN coalesce(r2.num_rbs, 0) = 0 THEN 'No RB to SignUp 2'
+        WHEN coalesce(r1.online_offline, '') = ''
+        AND coalesce(r2.online_offline, '') = '' THEN 'Both RB Online/Offline are Unknown'
+        WHEN coalesce(r1.online_offline, '') = '' THEN 'RB Online/Offline 1 is Unknown'
+        WHEN coalesce(r2.online_offline, '') = '' THEN 'RB Online/Offline 2 is Unknown'
+        WHEN r1.online_offline = r2.online_offline THEN concat('Both are ', r1.online_offline)
+        ELSE concat(
+            coalesce(r1.online_offline, 'Unknown'),
+            ' / ',
+            coalesce(r2.online_offline, 'Unknown')
+        )
+    END AS rb_online_offline_pattern,
+    --Report Back Action Types from Signup 1 & 2 Report Backs
+    r1.action_types AS rb_action_types_1,
+    r2.action_types AS rb_action_types_2,
+    CASE
+        WHEN coalesce(r1.num_rbs, 0) = 0
+        AND coalesce(r2.num_rbs, 0) = 0 THEN 'No RB to Either SignUp'
+        WHEN coalesce(r1.num_rbs, 0) = 0 THEN 'No RB to SignUp 1'
+        WHEN coalesce(r2.num_rbs, 0) = 0 THEN 'No RB to SignUp 2'
+        WHEN coalesce(r1.action_types, '') = ''
+        AND coalesce(r2.action_types, '') = '' THEN 'Both RB Action Types are Unknown'
+        WHEN coalesce(r1.action_types, '') = '' THEN 'RB Action Type 1 is Unknown'
+        WHEN coalesce(r2.action_types, '') = '' THEN 'RB Action Type 2 is Unknown'
+        WHEN r1.action_types LIKE concat('%', r2.action_types, '%')
+        OR r2.action_types LIKE concat('%', r1.action_types, '%') THEN 'Same'
+        ELSE 'Different'
+    END AS rb_action_types_pattern
+FROM
+    ns_signups ns1
+    LEFT JOIN ns_signup_2 ns2 ON (ns1.northstar_id = ns2.northstar_id)
+    JOIN { { ref('campaign_info') } } c1 ON (ns1.campaign_id = c1.campaign_id :: text)
+    LEFT JOIN { { ref('campaign_info') } } c2 ON (ns2.campaign_id = c2.campaign_id :: text)
+    LEFT JOIN { { ref('user_rb_summary') } } r1 ON (ns1.signup_id = r1.signup_id)
+    LEFT JOIN { { ref('user_rb_summary') } } r2 ON (ns2.signup_id = r2.signup_id)
+WHERE
+    ns1.nth_signup = 1

--- a/quasar/dbt/models/campaign_activity/schema.yml
+++ b/quasar/dbt/models/campaign_activity/schema.yml
@@ -245,3 +245,101 @@ models:
 
         - name: sms subscribed
           description: Whether the use is subscribed to SMS
+
+  - name: first_and_second_signups
+    description: A table that brings signups 1 & 2 (of the same user) into a single row along with previously generated campaign-level data. The goal is comparing them to determine whether there are patterns corresponding to better report-back rates.
+    columns:
+        - name: northstar_id
+          description: '{{ doc("northstar_id") }}'
+        - name: campaign_id_1
+          description: '{{ doc("campaign_id") }} for Signup #1'
+        - name: campaign_id_2
+          description: '{{ doc("campaign_id") }} for Signup #2'
+        - name: signup_id_1
+          description: '{{ doc("signup_id") }} #1'
+        - name: signup_id_2
+          description: '{{ doc("signup_id") }} #2'
+
+        - name: signup_source_bucket_1
+          description: '{{ doc("signup_source_bucket") }} for the first Signup'
+        - name: signup_source_bucket_2
+          description: '{{ doc("signup_source_bucket") }} for the second Signup'
+        - name: signup_source_bucket_pattern
+          description: 'Source Bucket pattern for both Signups e.g. (Both are Unknown, [sms|web|voter-reg|niche|Unknown / sms|web|voter-reg|niche|Unknown])'
+
+        - name: campaign_action_type_1
+          description: '{{ doc("campaign_action_type") }} for the first Signup'
+        - name: campaign_action_type_2
+          description: '{{ doc("campaign_action_type") }} for the second Signup'
+        - name: campaign_action_type_pattern
+          description: 'Campaign Action Type {{ doc("comparison_patterns") }}'
+
+        - name: campaign_cause_type_1
+          description: '{{ doc("campaign_cause_type") }} for the first Signup'
+        - name: campaign_cause_type_2
+          description: '{{ doc("campaign_cause_type") }} for the second Signup'
+        - name: campaign_cause_type_pattern
+          description: 'Campaign Cause Type {{ doc("comparison_patterns") }}'
+
+        - name: campaign_online_offline_1
+          description: Campaign for first Signup has (Online, Offline (IRL), or Both) types of Post Actions
+        - name: campaign_online_offline_2
+          description: Campaign for second Signup has (Online, Offline (IRL), or Both) types of Post Actions
+        - name: campaign_online_offline_pattern
+          description: 'Online Pattern (based on Post Actions) for the campaigns in both Signups e.g. (Both are Unknown, Both are [Both|Online|Offline|Unknown], [Both|Online|Offline|Unknown / Both|Online|Offline|Unknown])'
+
+        - name: campaign_action_types_1
+          description: '{{ doc("campaign_action_types") }} for the first Signup'
+        - name: campaign_action_types_2
+          description: '{{ doc("campaign_action_types") }} for the second Signup'
+        - name: campaign_action_types_pattern
+          description: 'Campaign Action Types {{ doc("comparison_patterns") }}'
+
+        - name: campaign_scholarship_1
+          description: Wether the Campaign for the first Signup is associated with a Scholarship -- if one of it's actions is setup as Scholarship Entry (e.g. Scholarship, Not Scholarship)
+        - name: campaign_scholarship_2
+          description: Wether the Campaign for the second Signup is associated with a Scholarship -- if one of it's actions is setup as Scholarship Entry (e.g. Scholarship, Not Scholarship)
+        - name: campaign_scholarship_pattern
+          description: 'Campaign Scholarship association pattern for both Signups e.g. (Both are Unknown, Both are [Scholarship|Not Scholarship|Unknown], [Scholarship|Not Scholarship|Unknown / Scholarship|Not Scholarship|Unknown])'
+
+        - name: campaign_post_types_1
+          description: '{{ doc("campaign_post_types") }} for the first Signup'
+        - name: campaign_post_types_2
+          description: '{{ doc("campaign_post_types") }} for the second Signup'
+        - name: campaign_post_types_pattern
+          description: 'Campaign Post Types {{ doc("comparison_patterns") }}'
+
+        - name: num_rbs_1
+          description: '{{ doc("num_rbs") }} for the first Signup'
+        - name: num_rbs_2
+          description: '{{ doc("num_rbs") }} for the second Signup'
+        - name: num_rbs_pattern
+          description: 'Num Reportbacks pattern for both Signups e.g. (No RB to Either SignUp, No RB to SignUp 1, No RB to SignUp 2, RB to Both SignUps)'
+
+        - name: rb_source_buckets_1
+          description: '{{ doc("post_source_buckets") }} for the first Signup'
+        - name: rb_source_buckets_2
+          description: '{{ doc("post_source_buckets") }} for the second Signup'
+        - name: rb_source_buckets_pattern
+          description: 'Post Sources pattern for both Signups e.g. (No RB to Either SignUp, [No RB|sms|web|sms , web|Unknown / No RB|sms|web|sms , web|Unknown])'
+
+        - name: rb_post_types_1
+          description: '{{ doc("post_types") }} for the first Signup'
+        - name: rb_post_types_2
+          description: '{{ doc("post_types") }} for the second Signup'
+        - name: rb_post_types_pattern
+          description: 'Post Types pattern for both Signups e.g. (No RB to Either SignUp, No RB to SignUp 1, No RB to SignUp 2, Both RB Post Types are Unknown, RB Post Type 1 is Unknown, RB Post Type 2 is Unknown, Same, Different)'
+
+        - name: rb_online_offline_1
+          description: '{{ doc("post_online_offline") }} for the first Signup'
+        - name: rb_online_offline_2
+          description: '{{ doc("post_online_offline") }} for the second Signup'
+        - name: rb_online_offline_pattern
+          description: 'Online/Offline posts pattern for both Signups e.g. (No RB to Either SignUp, No RB to SignUp 1, No RB to SignUp 2, Both RB Online/Offline are Unknown, RB Online/Offline 1 is Unknown, RB Online/Offline 2 is Unknown, Both are [Online|Offline|Online , Offline], [Online|Offline|Online , Offline|Unknown / Online|Offline|Online , Offline|Unknown])'
+
+        - name: rb_action_types_1
+          description: '{{ doc("post_action_types") }} for the first Signup'
+        - name: rb_action_types_2
+          description: '{{ doc("post_action_types") }} for the second Signup'
+        - name: rb_action_types_pattern
+          description: 'Post action types pattern for both Signups e.g. (No RB to Either SignUp, No RB to SignUp 1, No RB to SignUp 2, Both RB Action Types are Unknown, RB Action Type 1 is Unknown, RB Action Type 2 is Unknown, Same, Different)'

--- a/quasar/dbt/models/campaign_info/campaign_info.sql
+++ b/quasar/dbt/models/campaign_info/campaign_info.sql
@@ -1,13 +1,35 @@
 WITH
 --Campaigns with Online/Offline Post Components
 campaign_online AS (
-  SELECT campaign_id, count(DISTINCT online) AS online_count, min(CASE WHEN online=true THEN 'Online' ELSE 'Offline' END) AS min_online
-  FROM {{ ref('post_actions') }}
-  GROUP BY 1
+  SELECT
+    campaign_id,
+    -- Uses distinct count to check if
+    -- there is only online or only offline actions (Value would be 1)
+    -- there is a mix of online and offline (Value would be 2)
+    count(DISTINCT online) AS online_count,
+    -- If the campaign has only 1 action, min_online will hold "Online" or "Offline" accordingly.
+    -- If the campaign has any number of both types of actions min_online will always hold "Offline"
+    -- NOTE: Ignore in that case.
+    min(
+      CASE
+        WHEN online = TRUE THEN 'Online'
+        ELSE 'Offline'
+      END
+    ) AS min_online
+  FROM
+    { { ref('post_actions') } }
+  GROUP BY
+    1
 ),
 campaign_online_combo AS (
-    SELECT campaign_id, CASE WHEN online_count>1 THEN 'Both' ELSE min_online END AS online_offline
-    FROM campaign_online
+  SELECT
+    campaign_id,
+    CASE
+      WHEN online_count > 1 THEN 'Both'
+      ELSE min_online
+    END AS online_offline
+  FROM
+    campaign_online
 ),
 --Campaigns and Action Types
 campaign_action AS (

--- a/quasar/dbt/models/schema.md
+++ b/quasar/dbt/models/schema.md
@@ -23,12 +23,16 @@ ID of the broadcast that generated the shortened URL
 Source of the URL (e.g. SMS, web), origin of the post (e.g. phoenix-web, phoenix-ashes, sms), or source where user was acquired. (e.g. sms, phoenix-next)
 {% enddocs %}
 
-{% docs post_sources %}
-Sources of the Posts (e.g. sms, web)
+{% docs post_source_buckets %}
+Aggregated list of the grouping buckets for the origin of the posts (e.g. sms, web)
 {% enddocs %}
 
 {% docs post_types %}
-Types of Posts (e.g. photo, phone-call, share-social, text, voter-reg, email)
+Aggregated list of post types of the posts (e.g. photo, phone-call, share-social, text, voter-reg, email)
+{% enddocs %}
+
+{% docs campaign_post_types %}
+Aggregated list of post types of all the actions available for the campaign (e.g. photo, phone-call, share-social, text, voter-reg, email)
 {% enddocs %}
 
 {% docs interaction_type %}
@@ -56,7 +60,7 @@ Numerical quantity of items specified in the call to action (e.g. 10, 200)
 {% enddocs %}
 
 {% docs source_bucket %}
-Grouping bucket for origin of the post (e.g. web, sms) 
+Grouping bucket for the origin of the post (e.g. web, sms)
 {% enddocs %}
 
 {% docs created_at %}
@@ -167,12 +171,16 @@ Title of the campaign run
 Campaign action type (eg. Make Something, Share Something)
 {% enddocs %}
 
-{% docs action_types %}
-Types of actions of the Posts (e.g. attend-event, share-something, make-something, collect-something, contact-decisionmaker, donate-something, host-event, have-a-conversation, flag-content, sign-petition, submit-tip, other)
+{% docs post_action_types %}
+Aggregated list of Action Types of the Posts (e.g. attend-event, share-something, make-something, collect-something, contact-decisionmaker, donate-something, host-event, have-a-conversation, flag-content, sign-petition, submit-tip, other)
+{% enddocs %}
+
+{% docs campaign_action_types %}
+Aggregated list of Action Types of all the Actions available for the campaign (e.g. attend-event, share-something, make-something, collect-something, contact-decisionmaker, donate-something, host-event, have-a-conversation, flag-content, sign-petition, submit-tip, other)
 {% enddocs %}
 
 {% docs campaign_cause_type %}
-Campaign cause type (eg. Mental Health, Education)
+Campaign cause type (e.g. Mental Health, Education, Environment)
 {% enddocs %}
 
 {% docs campaign_noun %}
@@ -391,8 +399,8 @@ Type of action the user took. (e.g. share-something, donate-something)
 Whether the action is a online as opposed to IRL.
 {% enddocs %}
 
-{% docs online_offline %}
-Whether the action is online or offline (IRL).
+{% docs post_online_offline %}
+Aggregate. Whether the posts are online, offline (IRL), or both, e.g. ("Online", "Offline", "Online , Offline")
 {% enddocs %}
 
 {% docs time_commitment %}
@@ -691,6 +699,10 @@ Newsletter status, whether or not the user is subscribed to the newsletter
 Source of signup, e.g. "sms" or "web"
 {% enddocs %}
 
+{% docs signup_source_bucket %}
+Grouping bucket for origin of the signup, e.g. "sms", "web", "voter-reg" or "niche"
+{% enddocs %}
+
 {% docs signup_date %}
 Date when user signed up for newsletter
 {% enddocs %}
@@ -805,4 +817,8 @@ The most recent time the user registered to vote
 
 {% docs submit_quiz_register_affirmation %}
 Submitted the quiz, and then registered to vote
+{% enddocs %}
+
+{% docs comparison_patterns %}
+Pattern e.g. (Both are Unknown, One is Unknown, Same, Different)
 {% enddocs %}

--- a/quasar/dbt/models/user_activity/schema.yml
+++ b/quasar/dbt/models/user_activity/schema.yml
@@ -85,13 +85,13 @@ models:
           description: '{{ doc("first_rb") }}'
 
         - name: post_sources
-          description: '{{ doc("post_sources") }}'
+          description: '{{ doc("post_source_buckets") }}'
 
         - name: post_types
           description: '{{ doc("post_types") }}'
 
         - name: action_types
-          description: '{{ doc("action_types") }}'
+          description: '{{ doc("post_action_types") }}'
 
         - name: online_offline
-          description: '{{ doc("online_offline") }}'
+          description: '{{ doc("post_online_offline") }}'


### PR DESCRIPTION
#### What's this PR do?
- Adds new `first_and_second_signups` model provided by @eriqa w/ minor edits.

Tested manually against QA:

```
rpacas@Rafaels-MacBook-Pro
 in   ~/Desktop/repos/q/quasar/dbt (first-and-second-signups-model) $ pipenv run dbt run -m campaign_activity.first_and_second_signups --profile qa
Running with dbt=0.14.4
Found 40 models, 135 tests, 2 snapshots, 0 analyses, 117 macros, 0 operations, 0 seed files, 3 sources

10:24:24 | Concurrency: 4 threads (target='default')
10:24:24 | 
10:24:24 | 1 of 1 START table model public.first_and_second_signups............. [RUN]
10:27:25 | 1 of 1 OK created table model public.first_and_second_signups........ [SELECT 5401257 in 180.31s]
10:27:25 | 
10:27:25 | Finished running 1 table model in 182.87s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/172238952

