### PR TITLE
Ovrd quiz rtv steps

### DIFF
--- a/quasar/dbt/models/user_journey/ovrd_creator_funnel.sql
+++ b/quasar/dbt/models/user_journey/ovrd_creator_funnel.sql
@@ -88,7 +88,7 @@ nsid_less AS (
 			) AS clicked_get_started,
 		max(
 			CASE 
-				WHEN po.status IN (('step-2','step-3','step-4','ineligible','under-18','register-OVR','register-form'))
+				WHEN po.status IN ('step-2','step-3','step-4','ineligible','under-18','register-OVR','register-form')
 				THEN 1 ELSE 0 END
 			) AS rtv_step_2,
 		max(

--- a/quasar/dbt/models/user_journey/ovrd_creator_funnel.sql
+++ b/quasar/dbt/models/user_journey/ovrd_creator_funnel.sql
@@ -83,7 +83,7 @@ nsid_less AS (
 			) AS click_start_registration,
 		max(
 			CASE 
-				WHEN po.status='voter-reg' 
+				WHEN po."type"='voter-reg' 
 				THEN 1 ELSE 0 END
 			) AS clicked_get_started,
 		max(

--- a/quasar/dbt/models/user_journey/ovrd_creator_funnel.sql
+++ b/quasar/dbt/models/user_journey/ovrd_creator_funnel.sql
@@ -83,9 +83,29 @@ nsid_less AS (
 			) AS click_start_registration,
 		max(
 			CASE 
-				WHEN rtv.post_id IS NOT NULL 
+				WHEN po.status='voter-reg' 
 				THEN 1 ELSE 0 END
 			) AS clicked_get_started,
+		max(
+			CASE 
+				WHEN po.status IN (('step-2','step-3','step-4','ineligible','under-18','register-OVR','register-form'))
+				THEN 1 ELSE 0 END
+			) AS rtv_step_2,
+		max(
+			CASE 
+				WHEN po.status IN ('step-3','ineligible','under-18','register-form')
+				THEN 1 ELSE 0 END
+			) AS rtv_step_3,
+		max(
+			CASE 
+				WHEN po.status IN ('step-4','ineligible','under-18','register-OVR')
+				THEN 1 ELSE 0 END
+			) AS rtv_step_4,
+		max(
+			CASE 
+				WHEN po.status IN ('step-3','step-4','ineligible','under-18','register-OVR','register-form')
+				THEN 1 ELSE 0 END
+			) AS rtv_step_3_or_4,
 		max(
 			CASE 
 				WHEN reg.northstar_id IS NOT NULL 

--- a/quasar/dbt/models/user_journey/ovrd_recipient_funnel.sql
+++ b/quasar/dbt/models/user_journey/ovrd_recipient_funnel.sql
@@ -68,26 +68,30 @@ SELECT
 	--Earliest RTV record for the user is when they began registering
 	min(lg.event_ts)
 		FILTER(WHERE lg.event_name<>'page_visit') AS started_register_ts,
-	--If they have a started_registration event then they clicked get started
+	--If they have a any event then they clicked get started
 	max(
 		CASE 
 			WHEN lg.event_name IS NOT NULL THEN 1 ELSE 0 END
 		) AS clicked_get_started,
+	--If they have any of the following steps, they made it to step 2
 	max(
 		CASE 
 			WHEN po.event_name IN (('step-2','step-3','step-4','ineligible','under-18','register-OVR','register-form'))
 			THEN 1 ELSE 0 END
 		) AS rtv_step_2,
+	--If they have any of the following steps, they made it to step 3
 	max(
 		CASE 
 			WHEN po.event_name IN ('step-3','ineligible','under-18','register-form')
 			THEN 1 ELSE 0 END
 		) AS rtv_step_3,
+	--If they have any of the following steps, they made it to step 4
 	max(
 		CASE 
 			WHEN po.event_name IN ('step-4','ineligible','under-18','register-OVR')
 			THEN 1 ELSE 0 END
 		) AS rtv_step_4,
+	--If they have any of the following steps, they made it to step 3 or 4
 	max(
 		CASE 
 			WHEN po.event_name IN ('step-3','step-4','ineligible','under-18','register-OVR','register-form')

--- a/quasar/dbt/models/user_journey/ovrd_recipient_funnel.sql
+++ b/quasar/dbt/models/user_journey/ovrd_recipient_funnel.sql
@@ -41,7 +41,7 @@ WITH event_log AS (
 	SELECT DISTINCT 
 		p.northstar_id AS user_id,
 		rtv.started_registration AS event_ts, 
-		'started_registration' AS event_name
+		p.status AS event_name
 	FROM {{ ref('rock_the_vote') }} rtv 
 	LEFT JOIN {{ ref('posts') }} p ON p.id=rtv.post_id
 	WHERE 
@@ -71,8 +71,28 @@ SELECT
 	--If they have a started_registration event then they clicked get started
 	max(
 		CASE 
-			WHEN lg.event_name='started_registration' THEN 1 ELSE 0 END
+			WHEN lg.event_name IS NOT NULL THEN 1 ELSE 0 END
 		) AS clicked_get_started,
+		max(
+			CASE 
+				WHEN po.event_name IN (('step-2','step-3','step-4','ineligible','under-18','register-OVR','register-form'))
+				THEN 1 ELSE 0 END
+			) AS rtv_step_2,
+		max(
+			CASE 
+				WHEN po.event_name IN ('step-3','ineligible','under-18','register-form')
+				THEN 1 ELSE 0 END
+			) AS rtv_step_3,
+		max(
+			CASE 
+				WHEN po.event_name IN ('step-4','ineligible','under-18','register-OVR')
+				THEN 1 ELSE 0 END
+			) AS rtv_step_4,
+		max(
+			CASE 
+				WHEN po.event_name IN ('step-3','step-4','ineligible','under-18','register-OVR','register-form')
+				THEN 1 ELSE 0 END
+			) AS rtv_step_3_or_4,
 	--If they have a registration event then they registered
 	max(
 		CASE 

--- a/quasar/dbt/models/user_journey/ovrd_recipient_funnel.sql
+++ b/quasar/dbt/models/user_journey/ovrd_recipient_funnel.sql
@@ -73,26 +73,26 @@ SELECT
 		CASE 
 			WHEN lg.event_name IS NOT NULL THEN 1 ELSE 0 END
 		) AS clicked_get_started,
-		max(
-			CASE 
-				WHEN po.event_name IN (('step-2','step-3','step-4','ineligible','under-18','register-OVR','register-form'))
-				THEN 1 ELSE 0 END
-			) AS rtv_step_2,
-		max(
-			CASE 
-				WHEN po.event_name IN ('step-3','ineligible','under-18','register-form')
-				THEN 1 ELSE 0 END
-			) AS rtv_step_3,
-		max(
-			CASE 
-				WHEN po.event_name IN ('step-4','ineligible','under-18','register-OVR')
-				THEN 1 ELSE 0 END
-			) AS rtv_step_4,
-		max(
-			CASE 
-				WHEN po.event_name IN ('step-3','step-4','ineligible','under-18','register-OVR','register-form')
-				THEN 1 ELSE 0 END
-			) AS rtv_step_3_or_4,
+	max(
+		CASE 
+			WHEN po.event_name IN (('step-2','step-3','step-4','ineligible','under-18','register-OVR','register-form'))
+			THEN 1 ELSE 0 END
+		) AS rtv_step_2,
+	max(
+		CASE 
+			WHEN po.event_name IN ('step-3','ineligible','under-18','register-form')
+			THEN 1 ELSE 0 END
+		) AS rtv_step_3,
+	max(
+		CASE 
+			WHEN po.event_name IN ('step-4','ineligible','under-18','register-OVR')
+			THEN 1 ELSE 0 END
+		) AS rtv_step_4,
+	max(
+		CASE 
+			WHEN po.event_name IN ('step-3','step-4','ineligible','under-18','register-OVR','register-form')
+			THEN 1 ELSE 0 END
+		) AS rtv_step_3_or_4,
 	--If they have a registration event then they registered
 	max(
 		CASE 

--- a/quasar/dbt/models/user_journey/ovrd_recipient_funnel.sql
+++ b/quasar/dbt/models/user_journey/ovrd_recipient_funnel.sql
@@ -76,25 +76,25 @@ SELECT
 	--If they have any of the following steps, they made it to step 2
 	max(
 		CASE 
-			WHEN po.event_name IN (('step-2','step-3','step-4','ineligible','under-18','register-OVR','register-form'))
+			WHEN lg.event_name IN ('step-2','step-3','step-4','ineligible','under-18','register-OVR','register-form')
 			THEN 1 ELSE 0 END
 		) AS rtv_step_2,
 	--If they have any of the following steps, they made it to step 3
 	max(
 		CASE 
-			WHEN po.event_name IN ('step-3','ineligible','under-18','register-form')
+			WHEN lg.event_name IN ('step-3','ineligible','under-18','register-form')
 			THEN 1 ELSE 0 END
 		) AS rtv_step_3,
 	--If they have any of the following steps, they made it to step 4
 	max(
 		CASE 
-			WHEN po.event_name IN ('step-4','ineligible','under-18','register-OVR')
+			WHEN lg.event_name IN ('step-4','ineligible','under-18','register-OVR')
 			THEN 1 ELSE 0 END
 		) AS rtv_step_4,
 	--If they have any of the following steps, they made it to step 3 or 4
 	max(
 		CASE 
-			WHEN po.event_name IN ('step-3','step-4','ineligible','under-18','register-OVR','register-form')
+			WHEN lg.event_name IN ('step-3','step-4','ineligible','under-18','register-OVR','register-form')
 			THEN 1 ELSE 0 END
 		) AS rtv_step_3_or_4,
 	--If they have a registration event then they registered

--- a/quasar/dbt/models/voter_reg/voter_reg_quiz_funnel.sql
+++ b/quasar/dbt/models/voter_reg/voter_reg_quiz_funnel.sql
@@ -86,6 +86,54 @@ nsid_less AS (
 			) AS clicked_get_started,	
 		max(
 			CASE 
+				WHEN rtv.status IN (('Step 2','Step 3','Step 4','Rejected','Under 18','Complete'))
+				AND rtv.tracking_source ILIKE '%VoterRegQuiz_Affirmation%'
+				THEN 1 ELSE 0 END
+			) AS rtv_step_2_affirmation,
+		max(
+			CASE 
+				WHEN rtv.status IN (('Step 2','Step 3','Step 4','Rejected','Under 18','Complete'))
+				AND rtv.tracking_source ILIKE '%VoterRegQuiz_completed%'
+				THEN 1 ELSE 0 END
+			) AS rtv_step_2_quizcomplete,
+		max(
+			CASE 
+				WHEN rtv.status IN ('Step 3','Step 4','Rejected','Under 18','Complete')
+				AND rtv.tracking_source ILIKE '%VoterRegQuiz_Affirmation%'
+				THEN 1 ELSE 0 END
+			) AS rtv_step_3_affirmation,
+		max(
+			CASE 
+				WHEN rtv.status IN ('Step 3','Step 4','Rejected','Under 18','Complete')
+				AND rtv.tracking_source ILIKE '%VoterRegQuiz_completed%'
+				THEN 1 ELSE 0 END
+			) AS rtv_step_3_quizcomplete,
+		max(
+			CASE 
+				WHEN rtv.status IN ('Step 4','Rejected','Under 18','Complete')
+				AND rtv.tracking_source ILIKE '%VoterRegQuiz_Affirmation%'
+				THEN 1 ELSE 0 END
+			) AS rtv_step_4_affirmation,
+		max(
+			CASE 
+				WHEN rtv.status IN ('Step 4','Rejected','Under 18','Complete')
+				AND rtv.tracking_source ILIKE '%VoterRegQuiz_completed%'
+				THEN 1 ELSE 0 END
+			) AS rtv_step_4_quizcomplete,
+		max(
+			CASE 
+				WHEN po.status IN ('Step 3','Step 4','Rejected','Under 18','Complete')
+				AND rtv.tracking_source ILIKE '%VoterRegQuiz_Affirmation%'
+				THEN 1 ELSE 0 END
+			) AS rtv_step_3_or_4_affirmation,
+		max(
+			CASE 
+				WHEN po.status IN ('Step 3','Step 4','Rejected','Under 18','Complete')
+				AND rtv.tracking_source ILIKE '%VoterRegQuiz_completed%'
+				THEN 1 ELSE 0 END
+			) AS rtv_step_3_or_4_quizcomplete,
+		max(
+			CASE 
 				WHEN rtv.post_id IS NOT NULL AND rtv.tracking_source ILIKE '%VoterRegQuiz_Affirmation%'
 				THEN 1 ELSE 0 END
 			) AS clicked_get_started_affirmation,

--- a/quasar/dbt/models/voter_reg/voter_reg_quiz_funnel.sql
+++ b/quasar/dbt/models/voter_reg/voter_reg_quiz_funnel.sql
@@ -122,13 +122,13 @@ nsid_less AS (
 			) AS rtv_step_4_quizcomplete,
 		max(
 			CASE 
-				WHEN po.status IN ('Step 3','Step 4','Rejected','Under 18','Complete')
+				WHEN rtv.status IN ('Step 3','Step 4','Rejected','Under 18','Complete')
 				AND rtv.tracking_source ILIKE '%VoterRegQuiz_Affirmation%'
 				THEN 1 ELSE 0 END
 			) AS rtv_step_3_or_4_affirmation,
 		max(
 			CASE 
-				WHEN po.status IN ('Step 3','Step 4','Rejected','Under 18','Complete')
+				WHEN rtv.status IN ('Step 3','Step 4','Rejected','Under 18','Complete')
 				AND rtv.tracking_source ILIKE '%VoterRegQuiz_completed%'
 				THEN 1 ELSE 0 END
 			) AS rtv_step_3_or_4_quizcomplete,

--- a/quasar/dbt/models/voter_reg/voter_reg_quiz_funnel.sql
+++ b/quasar/dbt/models/voter_reg/voter_reg_quiz_funnel.sql
@@ -86,13 +86,13 @@ nsid_less AS (
 			) AS clicked_get_started,	
 		max(
 			CASE 
-				WHEN rtv.status IN (('Step 2','Step 3','Step 4','Rejected','Under 18','Complete'))
+				WHEN rtv.status IN ('Step 2','Step 3','Step 4','Rejected','Under 18','Complete')
 				AND rtv.tracking_source ILIKE '%VoterRegQuiz_Affirmation%'
 				THEN 1 ELSE 0 END
 			) AS rtv_step_2_affirmation,
 		max(
 			CASE 
-				WHEN rtv.status IN (('Step 2','Step 3','Step 4','Rejected','Under 18','Complete'))
+				WHEN rtv.status IN ('Step 2','Step 3','Step 4','Rejected','Under 18','Complete')
 				AND rtv.tracking_source ILIKE '%VoterRegQuiz_completed%'
 				THEN 1 ELSE 0 END
 			) AS rtv_step_2_quizcomplete,


### PR DESCRIPTION
#### What's this PR do?
* Adds RTV step funnel flags to quiz and OVRD funnels
#### Where should the reviewer start?
* quasar/dbt/models/user_journey/ovrd_creator_funnel.sql
* quasar/dbt/models/user_journey/ovrd_recipient_funnel.sql
* quasar/dbt/models/voter_reg/voter_reg_quiz_funnel.sql
#### How should this be manually tested?
* Run in QA
#### Any background context you want to provide?
* RTV records the latest step that a user was on before they dropped off. We can infer that whatever that step is, they completed all prior steps. This allows us to see in greater detail the stage in the user journey they fall off
* This still relies on the public.rock_the_vote table, which we know has some issues. 
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/171891303
https://www.pivotaltracker.com/story/show/172424653
