### PR TITLE
Readding user_rb_summary to user_activity. Deleted on previous merge

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -207,6 +207,13 @@ models:
            - "CREATE INDEX IF NOT EXISTS most_recent_all_actions_i ON {{ this }}(most_recent_all_actions)"
            - "GRANT SELECT ON {{ this }} TO dsanalyst"
            - "GRANT SELECT ON {{ this }} TO looker"
+        user_rb_summary:
+          alias: user_rb_summary
+          materialized: table
+          post-hook:
+           - "CREATE UNIQUE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_unique_i ON {{ this }}(signup_id)"
+           - "GRANT SELECT ON {{ this }} TO dsanalyst"
+           - "GRANT SELECT ON {{ this }} TO looker"
         user_engagement_actions:
           alias: user_engagement_actions
           materialized: table


### PR DESCRIPTION
#### What's this PR do?
My last PR for User Engagement seems to have removed the `user_rb_summary` entry in the `dbt_project.yml` file. This PR readds it. 

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
