### PR TITLE
Northstar schema was removed from prod, fixing dump

### DIFF
--- a/quasar/prod_to_qa.py
+++ b/quasar/prod_to_qa.py
@@ -23,7 +23,7 @@ prod_pg_opts = {
 def main():
     schemas = ["analyst_sandbox", "bertly", "cio", "dosomething",
                "ft_dosomething_rogue", "ft_gambit_conversations_api",
-               "ft_snowplow", "northstar", "northstar_ft_userapi", "public"]
+               "ft_snowplow", "northstar_ft_userapi", "public"]
 
     for schema in schemas:
         psql(pg_dump(


### PR DESCRIPTION
#### What's this PR do?
This removes the `northstar` schema from the dump. It was removed from production and the dump script was breaking. `pg_dump` only has an `--if-exists` flag for cleaning targets, so I'm just removing this for now. In the future, the script can be updated to check if the schema exists before starting the dump commands.
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/172880266
#### Screenshots (if appropriate)
#### Questions:
