### PR TITLE
Adding additional uniqueness to index to fix name collision

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -56,7 +56,7 @@ models:
           alias: snowplow_phoenix_events
           materialized: table
           post-hook:
-            - "CREATE UNIQUE INDEX IF NOT EXISTS spe_unique ON {{ this }}(event_datetime, event_name, event_id)"
+            - "CREATE UNIQUE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_event_datetime_event_name_event_id_u___{{ run_started_at.timestamp()|int }} ON {{ this }}(event_datetime, event_name, event_id)"
             - "CREATE INDEX IF NOT EXISTS spe_session_id ON {{ this }} (session_id)"
             - "GRANT SELECT ON {{ this }} TO looker"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"


### PR DESCRIPTION
#### What's this PR do?
This PR adds some uniqueness to the `snowplow_phoenix_events` table creation since the jobs have repeatedly been failing on this error:
```
06:00:35 | Concurrency: 6 threads (target='prod')
06:00:35 | 
06:00:35 | 1 of 7 START table model public.snowplow_base_event.................. [RUN]
06:00:35 | 2 of 7 START table model public.snowplow_payload_event............... [RUN]
07:48:50 | 2 of 7 OK created table model public.snowplow_payload_event.......... [SELECT 43867090 in 6494.85s]
07:50:44 | 1 of 7 OK created table model public.snowplow_base_event............. [SELECT 43882844 in 6609.02s]
07:50:44 | 3 of 7 START table model public.snowplow_raw_events.................. [RUN]
16:11:30 | 3 of 7 OK created table model public.snowplow_raw_events............. [SELECT 43882844 in 30046.39s]
16:11:30 | 4 of 7 START table model public.snowplow_phoenix_events.............. [RUN]
16:18:35 | 4 of 7 ERROR creating table model public.snowplow_phoenix_events..... [ERROR in 424.14s]
16:18:35 | 5 of 7 SKIP relation public.snowplow_sessions........................ [SKIP]
16:18:35 | 6 of 7 SKIP relation public.phoenix_events_combined.................. [SKIP]
16:18:35 | 7 of 7 SKIP relation public.phoenix_sessions_combined................ [SKIP]
16:18:35 | 
16:18:35 | Finished running 7 table models in 37081.14s.

Completed with 1 error and 0 warnings:

Database Error in model snowplow_phoenix_events (models/phoenix_events/snowplow_phoenix_events.sql)
  could not create unique index "spe_unique"
  DETAIL:  Key (event_datetime, event_name, event_id)=(2019-08-10 03:20:24.668+00, view, 26537b6c-e91d-4b9c-b972-daaed765ba0a) is duplicated.
  compiled SQL at ../../docs/run/ds_dbt/phoenix_events/snowplow_phoenix_events.sql

Done. PASS=6 WARN=0 ERROR=1 SKIP=0 TOTAL=7
```
https://jenkins.d12g.co/job/Snowplow%20Events%20Recreate/
#### Where should the reviewer start?
#### How should this be manually tested?
Once this has been tested in QA, we should run it as soon as possible in production to see if it fixes the issue.
#### Any background context you want to provide?
Additional details in the ticket, but a DBT issue points to the fact that there may be index name collisions with backup tables. 
#### What are the relevant tickets?
https://www.pivotaltracker.com/n/projects/2328687/stories/172896625
#### Screenshots (if appropriate)
#### Questions:
