### PR TITLE
Index name was too long, shortened so timestamp works

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -56,7 +56,7 @@ models:
           alias: snowplow_phoenix_events
           materialized: table
           post-hook:
-            - "CREATE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_spe_unique___{{ run_started_at.timestamp()|int }} ON {{ this }}(event_datetime, event_name, event_id)"
+            - "CREATE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_spe_unique_{{ run_started_at.timestamp()|int }} ON {{ this }}(event_datetime, event_name, event_id)"
             - "CREATE INDEX IF NOT EXISTS spe_session_id ON {{ this }} (session_id)"
             - "GRANT SELECT ON {{ this }} TO looker"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"

--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -56,7 +56,7 @@ models:
           alias: snowplow_phoenix_events
           materialized: table
           post-hook:
-            - "CREATE UNIQUE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_event_datetime_event_name_event_id_u___{{ run_started_at.timestamp()|int }} ON {{ this }}(event_datetime, event_name, event_id)"
+            - "CREATE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_spe_unique___{{ run_started_at.timestamp()|int }} ON {{ this }}(event_datetime, event_name, event_id)"
             - "CREATE INDEX IF NOT EXISTS spe_session_id ON {{ this }} (session_id)"
             - "GRANT SELECT ON {{ this }} TO looker"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"


### PR DESCRIPTION
#### What's this PR do?
Earlier I updated the index for `snowplow_phoenix_events` that kept failing. Unfortunately it was still failing in QA. It looks like the index name was too long, so I've shortened that and tested again from my local, and the index is created properly.
#### Where should the reviewer start?
#### How should this be manually tested?
Tested locally:
```
└─▪ dbt run -m phoenix_events.snowplow_phoenix_events --profile qa --target qa
Running with dbt=0.14.4
Found 45 models, 135 tests, 2 snapshots, 0 analyses, 117 macros, 0 operations, 0 seed files, 4 sources

23:57:26 | Concurrency: 1 threads (target='qa')
23:57:26 |
23:57:26 | 1 of 1 START table model public.snowplow_phoenix_events.............. [RUN]
23:57:27 | 1 of 1 OK created table model public.snowplow_phoenix_events......... [SELECT 138933 in 1.24s]
23:57:27 |
23:57:27 | Finished running 1 table model in 2.40s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
Index that was created: `public_snowplow_phoenix_events_spe_unique___1589860641 ON public.snowplow_phoenix_events`
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/n/projects/2328687/stories/172896625
#### Screenshots (if appropriate)
#### Questions:
