### PR TITLE
Adds missing ENV variable to github action that builds DBT docs

### DIFF
--- a/.github/workflows/dbt-docs.yml
+++ b/.github/workflows/dbt-docs.yml
@@ -39,6 +39,7 @@ jobs:
           CAMPAIGN_INFO_ASHES_SNAPSHOT: ${{ secrets.CAMPAIGN_INFO_ASHES_SNAPSHOT }}
           TMC_USERS_MATCHED_SOURCE: ${{ secrets.TMC_USERS_MATCHED_SOURCE }}
           HISTORICAL_ANALYTICS_SCHEMA: ${{ secrets.HISTORICAL_ANALYTICS_SCHEMA }}
+          CIO_WEBHOOK_EVENTS_SCHEMA: ${{ secrets.CIO_WEBHOOK_EVENTS_SCHEMA }}
       - name: Move docs files to root dir
         run: |
           mv ./docs ~/


### PR DESCRIPTION
#### What's this PR do?
- Adds missing ENV variable `CIO_WEBHOOK_EVENTS_SCHEMA` to github action workflow that builds DBT docs
