### PR TITLE
Fix email_clicked missing event in cio_email_event model

### DIFF
--- a/quasar/dbt/models/cio/cio_email_event.sql
+++ b/quasar/dbt/models/cio/cio_email_event.sql
@@ -19,7 +19,7 @@ SELECT
 	event #>>'{data, variables, campaign, type}' as cio_campaign_type
 FROM
     {{ source('cio', 'event_log') }} cel
-WHERE event #>>'{data, event_type}' IN ('email_bounced', 'email_converted', 'email_opened', 'email_unsubscribed')
+WHERE event #>>'{data, event_type}' IN ('email_bounced', 'email_converted', 'email_opened', 'email_unsubscribed', 'email_clicked')
 UNION
 SELECT
     email_id,


### PR DESCRIPTION
#### What's this PR do?
- Fixes a bug that prevented `email_clicked` events from reaching `cio_email_event` table.
