### PR TITLE
Bug/fix json path to event type

### DIFF
--- a/quasar/dbt/models/cio/cio_email_event.sql
+++ b/quasar/dbt/models/cio/cio_email_event.sql
@@ -12,7 +12,7 @@ SELECT
 	event #>>'{data, href}' as href,
 	event #>>'{data, link_id}' as link_id,
 	event ->> 'event_id' AS event_id,
-	event #>>'{data, event_type}' as event_type,
+	event ->> 'event_type' as event_type,
 	TO_TIMESTAMP(CAST(event ->> 'timestamp' AS INTEGER)) AS "timestamp",
 	event #>>'{data, variables, campaign, id}' as cio_campaign_id,
 	event #>>'{data, variables, campaign, name}' as cio_campaign_name,

--- a/quasar/dbt/models/cio/cio_email_sent_event.sql
+++ b/quasar/dbt/models/cio/cio_email_sent_event.sql
@@ -33,7 +33,7 @@ SELECT
     NULL AS cio_campaign_name,
     NULL AS cio_campaign_type
 FROM
-    {{ source('cio', 'email_sent_old') }} ceso -- Date we re-started saving raw C.io events to the event_log table
+    {{ source('cio', 'email_sent_old') }} ceso
 WHERE
     -- Date we re-started saving raw C.io events to the event_log table
     "timestamp" < '2020-04-01'


### PR DESCRIPTION
#### What's this PR do?
- Fixes last wrong syntax to get `event_type` from the JSON requests in `cio.event_log`.
#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/172967003