### PR TITLE
Snowplow incremental

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -34,8 +34,6 @@ models:
   ds_dbt:
       # Applies to all files under models/phoenix_events/
       phoenix_events:
-        vars:
-            run_interval: "to_timestamp({{ run_started_at.timestamp()|int }}) - INTERVAL {{env_var('SNOWPLOW_INTERVAL')}}"
         snowplow_base_event:
           alias: snowplow_base_event
           materialized: incremental
@@ -58,7 +56,7 @@ models:
           alias: snowplow_phoenix_events
           materialized: incremental
           post-hook:
-            - "CREATE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_spe_{{ run_started_at.timestamp()|int }} ON {{ this }}(event_datetime, event_name, event_id)"
+            - "CREATE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_spe ON {{ this }}(event_datetime, event_name, event_id)"
             - "CREATE INDEX IF NOT EXISTS spe_session_id ON {{ this }} (session_id)"
             - "GRANT SELECT ON {{ this }} TO looker"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"
@@ -72,7 +70,7 @@ models:
           alias: phoenix_events_combined
           materialized: incremental
           post-hook:
-            - "CREATE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_pec_{{ run_started_at.timestamp()|int }} ON {{ this }}(event_datetime, event_name, event_id)"
+            - "CREATE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_pec ON {{ this }}(event_datetime, event_name, event_id)"
             - "CREATE INDEX IF NOT EXISTS pec_session_id ON {{ this }} (session_id)"
             - "GRANT SELECT ON {{ this }} TO looker"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"

--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -72,7 +72,7 @@ models:
           alias: phoenix_events_combined
           materialized: incremental
           post-hook:
-            - "CREATE UNIQUE INDEX IF NOT EXISTS pec_unique ON {{ this }}(event_datetime, event_name, event_id)"
+            - "CREATE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_pec_{{ run_started_at.timestamp()|int }} ON {{ this }}(event_datetime, event_name, event_id)"
             - "CREATE INDEX IF NOT EXISTS pec_session_id ON {{ this }} (session_id)"
             - "GRANT SELECT ON {{ this }} TO looker"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"

--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -34,41 +34,43 @@ models:
   ds_dbt:
       # Applies to all files under models/phoenix_events/
       phoenix_events:
+        vars:
+            run_interval: "to_timestamp({{ run_started_at.timestamp()|int }}) - INTERVAL {{env_var('SNOWPLOW_INTERVAL')}}"
         snowplow_base_event:
           alias: snowplow_base_event
-          materialized: table
+          materialized: incremental
           post-hook:
            - "CREATE INDEX IF NOT EXISTS event_index ON {{ this }}(event_id)"
            - "GRANT SELECT ON {{ this }} TO dsanalyst"
         snowplow_payload_event:
           alias: snowplow_payload_event
-          materialized: table
+          materialized: incremental
           post-hook:
            - "CREATE INDEX IF NOT EXISTS payload_event_id ON {{ this }}(event_id)"
            - "GRANT SELECT ON {{ this }} TO dsanalyst"
         snowplow_raw_events:
           alias: snowplow_raw_events
-          materialized: table
+          materialized: incremental
           post-hook:
             - "CREATE INDEX IF NOT EXISTS raw_event_id ON {{ this }}(event_id)"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"
         snowplow_phoenix_events:
           alias: snowplow_phoenix_events
-          materialized: table
+          materialized: incremental
           post-hook:
-            - "CREATE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_spe_unique_{{ run_started_at.timestamp()|int }} ON {{ this }}(event_datetime, event_name, event_id)"
+            - "CREATE INDEX IF NOT EXISTS {{ this.schema ~ '_' ~ this.table }}_spe_{{ run_started_at.timestamp()|int }} ON {{ this }}(event_datetime, event_name, event_id)"
             - "CREATE INDEX IF NOT EXISTS spe_session_id ON {{ this }} (session_id)"
             - "GRANT SELECT ON {{ this }} TO looker"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"
         snowplow_sessions:
-          materialized: table
+          materialized: incremental
           post-hook:
             - "CREATE INDEX IF NOT EXISTS sps_landing ON {{ this }}(landing_datetime, landing_page)"
             - "GRANT SELECT ON {{ this }} TO looker"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"
         phoenix_events_combined:
           alias: phoenix_events_combined
-          materialized: table
+          materialized: incremental
           post-hook:
             - "CREATE UNIQUE INDEX IF NOT EXISTS pec_unique ON {{ this }}(event_datetime, event_name, event_id)"
             - "CREATE INDEX IF NOT EXISTS pec_session_id ON {{ this }} (session_id)"
@@ -76,7 +78,7 @@ models:
             - "GRANT SELECT ON {{ this }} TO dsanalyst"
         phoenix_sessions_combined:
           alias: phoenix_sessions_combined
-          materialized: table
+          materialized: incremental
           post-hook:
             - "CREATE INDEX IF NOT EXISTS psc_landing ON {{ this }}(landing_datetime, landing_page)"
             - "GRANT SELECT ON {{ this }} TO looker"

--- a/quasar/dbt/models/phoenix_events/phoenix_events_combined.sql
+++ b/quasar/dbt/models/phoenix_events/phoenix_events_combined.sql
@@ -27,7 +27,7 @@ FROM
     {{ source('web_events_historical', 'phoenix_events') }} p
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-    WHERE p.event_datetime >= {{ var('run_interval') }}
+    WHERE p.event_datetime >= (SELECT max(pec.event_datetime) FROM {{this}} pec)
 {% endif %}
 UNION ALL
 SELECT DISTINCT ON(s.event_datetime, s.event_name, s.event_id)
@@ -59,5 +59,5 @@ FROM
     {{ ref('snowplow_phoenix_events') }} s
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-WHERE s.event_datetime >= {{ var('run_interval') }}
+WHERE s.event_datetime >= (select max(pec.event_datetime) from {{this}} pec)
 {% endif %}

--- a/quasar/dbt/models/phoenix_events/phoenix_events_combined.sql
+++ b/quasar/dbt/models/phoenix_events/phoenix_events_combined.sql
@@ -53,3 +53,8 @@ SELECT
     s.device_id
 FROM
     {{ ref('snowplow_phoenix_events') }} s
+
+{% if is_incremental() %}
+-- this filter will only be applied on an incremental run
+WHERE s.event_datetime >= {{ var('run_interval') }}
+{% endif %}

--- a/quasar/dbt/models/phoenix_events/phoenix_events_combined.sql
+++ b/quasar/dbt/models/phoenix_events/phoenix_events_combined.sql
@@ -1,4 +1,4 @@
-SELECT
+SELECT DISTINCT ON(p.event_datetime, p.event_name, p.event_id)
     p.event_id,
     p.event_datetime,
     p.event_name,
@@ -25,8 +25,12 @@ SELECT
     p.device_id
 FROM
     {{ source('web_events_historical', 'phoenix_events') }} p
+{% if is_incremental() %}
+-- this filter will only be applied on an incremental run
+    WHERE p.event_datetime >= {{ var('run_interval') }}
+{% endif %}
 UNION ALL
-SELECT
+SELECT DISTINCT ON(s.event_datetime, s.event_name, s.event_id)
     s.event_id,
     s.event_datetime,
     s.event_name,
@@ -53,7 +57,6 @@ SELECT
     s.device_id
 FROM
     {{ ref('snowplow_phoenix_events') }} s
-
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
 WHERE s.event_datetime >= {{ var('run_interval') }}

--- a/quasar/dbt/models/phoenix_events/phoenix_sessions_combined.sql
+++ b/quasar/dbt/models/phoenix_events/phoenix_sessions_combined.sql
@@ -15,7 +15,7 @@ SELECT
 FROM {{ source('web_events_historical', 'phoenix_sessions') }} p
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-WHERE p.landing_datetime >= {{ var('run_interval') }}
+WHERE p.landing_datetime >= (select max(psc.landing_datetime) from {{this}} psc)
 {% endif %}
 UNION ALL
 SELECT
@@ -35,6 +35,6 @@ SELECT
 FROM {{ ref('snowplow_sessions') }} s
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-WHERE s.landing_datetime >= {{ var('run_interval') }}
+WHERE s.landing_datetime >= (select max(psc.landing_datetime) from {{this}} psc)
 {% endif %}
 

--- a/quasar/dbt/models/phoenix_events/phoenix_sessions_combined.sql
+++ b/quasar/dbt/models/phoenix_events/phoenix_sessions_combined.sql
@@ -13,6 +13,10 @@ SELECT
     NULL as exit_page,
     NULL as days_since_last_session
 FROM {{ source('web_events_historical', 'phoenix_sessions') }} p
+{% if is_incremental() %}
+-- this filter will only be applied on an incremental run
+WHERE p.landing_datetime >= {{ var('run_interval') }}
+{% endif %}
 UNION ALL
 SELECT
     s.session_id,
@@ -29,9 +33,8 @@ SELECT
     s.exit_page,
     s.days_since_last_session
 FROM {{ ref('snowplow_sessions') }} s
-
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-WHERE p.landing_datetime >= {{ var('run_interval') }}
+WHERE s.landing_datetime >= {{ var('run_interval') }}
 {% endif %}
 

--- a/quasar/dbt/models/phoenix_events/phoenix_sessions_combined.sql
+++ b/quasar/dbt/models/phoenix_events/phoenix_sessions_combined.sql
@@ -30,3 +30,8 @@ SELECT
     s.days_since_last_session
 FROM {{ ref('snowplow_sessions') }} s
 
+{% if is_incremental() %}
+-- this filter will only be applied on an incremental run
+WHERE p.landing_datetime >= {{ var('run_interval') }}
+{% endif %}
+

--- a/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
@@ -63,5 +63,5 @@ WHERE event_id NOT IN
 
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-AND collector_tstamp >= {{ var('run_interval') }}
+AND collector_tstamp >= (select max(sp_event.event_datetime) from {{this}} sp_event)
 {% endif %}

--- a/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
@@ -63,5 +63,5 @@ WHERE event_id NOT IN
 
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-AND collector_tstamp.event_datetime >= {{ var('run_interval') }}
+AND collector_tstamp >= {{ var('run_interval') }}
 {% endif %}

--- a/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
@@ -54,9 +54,14 @@ SELECT
     refr_urlhost AS referrer_host,
     refr_urlpath AS referrer_path,
     refr_source AS referrer_source
-  FROM {{ env_var('FT_SNOWPLOW') }}."event"
-  WHERE event_id NOT IN
-  (SELECT event_id
-   FROM {{ env_var('FT_SNOWPLOW') }}.ua_parser_context u
-   WHERE u.useragent_family SIMILAR TO
-   '%(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|YandexBot|Twitterbot|a_archiver|facebookexternalhit|Bingbot|Googlebot|Baiduspider|360(Spider|User-agent)|Ghost)%')
+FROM {{ env_var('FT_SNOWPLOW') }}."event"
+WHERE event_id NOT IN
+(SELECT event_id
+ FROM {{ env_var('FT_SNOWPLOW') }}.ua_parser_context u
+ WHERE u.useragent_family SIMILAR TO
+ '%(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|YandexBot|Twitterbot|a_archiver|facebookexternalhit|Bingbot|Googlebot|Baiduspider|360(Spider|User-agent)|Ghost)%')
+
+{% if is_incremental() %}
+-- this filter will only be applied on an incremental run
+AND collector_tstamp.event_datetime >= {{ var('run_interval') }}
+{% endif %}

--- a/quasar/dbt/models/phoenix_events/snowplow_payload_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_payload_event.sql
@@ -14,5 +14,5 @@ FROM {{ env_var('FT_SNOWPLOW') }}.snowplow_event
 
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-WHERE collector_tstamp.event_datetime >= {{ var('run_interval') }}
+WHERE _fivetran_synced >= {{ var('run_interval') }}
 {% endif %}

--- a/quasar/dbt/models/phoenix_events/snowplow_payload_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_payload_event.sql
@@ -10,4 +10,9 @@ SELECT
     payload::jsonb #>> '{contextSource}' AS context_source,
     payload::jsonb #>> '{value}' AS context_value,
     _fivetran_synced AS ft_timestamp
-  FROM {{ env_var('FT_SNOWPLOW') }}.snowplow_event
+FROM {{ env_var('FT_SNOWPLOW') }}.snowplow_event
+
+{% if is_incremental() %}
+-- this filter will only be applied on an incremental run
+WHERE collector_tstamp.event_datetime >= {{ var('run_interval') }}
+{% endif %}

--- a/quasar/dbt/models/phoenix_events/snowplow_payload_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_payload_event.sql
@@ -14,5 +14,5 @@ FROM {{ env_var('FT_SNOWPLOW') }}.snowplow_event
 
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-WHERE _fivetran_synced >= {{ var('run_interval') }}
+WHERE _fivetran_synced >= (select max(spe.ft_timestamp) from {{this}} spe)
 {% endif %}

--- a/quasar/dbt/models/phoenix_events/snowplow_phoenix_events.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_phoenix_events.sql
@@ -27,3 +27,8 @@ SELECT DISTINCT ON (e.EVENT_ID)
     e.device_id
 FROM {{ ref('snowplow_raw_events') }} e
 LEFT JOIN {{ ref('campaign_info') }} i ON i.campaign_id = e.campaign_id::bigint
+
+{% if is_incremental() %}
+-- this filter will only be applied on an incremental run
+WHERE e.event_datetime >= {{ var('run_interval') }}
+{% endif %}

--- a/quasar/dbt/models/phoenix_events/snowplow_phoenix_events.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_phoenix_events.sql
@@ -30,5 +30,5 @@ LEFT JOIN {{ ref('campaign_info') }} i ON i.campaign_id = e.campaign_id::bigint
 
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-WHERE e.event_datetime >= {{ var('run_interval') }}
+WHERE event_datetime >= {{ var('run_interval') }}
 {% endif %}

--- a/quasar/dbt/models/phoenix_events/snowplow_phoenix_events.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_phoenix_events.sql
@@ -30,5 +30,5 @@ LEFT JOIN {{ ref('campaign_info') }} i ON i.campaign_id = e.campaign_id::bigint
 
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-WHERE event_datetime >= {{ var('run_interval') }}
+WHERE event_datetime >= (select max(spe.event_datetime) from {{this}} spe)
 {% endif %}

--- a/quasar/dbt/models/phoenix_events/snowplow_raw_events.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_raw_events.sql
@@ -32,6 +32,6 @@ SELECT
   ON b.event_id = p.event_id
 
 {% if is_incremental() %}
--- this filter will only be applied on an incremental run
-WHERE b.event_datetime >= {{ var('run_interval') }}
+  -- this filter will only be applied on an incremental run
+  WHERE b.event_datetime >= {{ var('run_interval') }}
 {% endif %}

--- a/quasar/dbt/models/phoenix_events/snowplow_raw_events.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_raw_events.sql
@@ -33,5 +33,5 @@ SELECT
 
 {% if is_incremental() %}
   -- this filter will only be applied on an incremental run
-  WHERE b.event_datetime >= {{ var('run_interval') }}
+  WHERE b.event_datetime >= (select max(sre.event_datetime) from {{this}} sre)
 {% endif %}

--- a/quasar/dbt/models/phoenix_events/snowplow_raw_events.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_raw_events.sql
@@ -30,3 +30,8 @@ SELECT
   FROM {{ ref('snowplow_base_event') }} b
   LEFT JOIN {{ ref('snowplow_payload_event') }} p 
   ON b.event_id = p.event_id
+
+{% if is_incremental() %}
+-- this filter will only be applied on an incremental run
+WHERE b.event_datetime >= {{ var('run_interval') }}
+{% endif %}

--- a/quasar/dbt/models/phoenix_events/snowplow_sessions.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_sessions.sql
@@ -70,3 +70,8 @@ LEFT JOIN session_referrer r
 ON r.session_id = s.session_id
 LEFT JOIN time_between_sessions t
 ON t.session_id = s.session_id
+
+{% if is_incremental() %}
+-- this filter will only be applied on an incremental run
+WHERE s.landing_datetime >= {{ var('run_interval') }}
+{% endif %}


### PR DESCRIPTION
#### What's this PR do?
This PR adds the logic to incrementally build the Snowplow models. This sets a DBT variable that uses an ENV var with an interval that allows us to adjust the increment window for Snowplow updates. I preferred to use something like max(event_datetime), but Postgres doesn't allow aggregate functions in `WHERE` clauses. With our time savings on running incremental builds, we should be able to rely on `DISTINCT` to remove duplicates.

I've set the env var in QA in production:
`export SNOWPLOW_INTERVAL="'24 HOURS'"`

#### Where should the reviewer start?
#### How should this be manually tested?
This has been tested with the following commands:
```
└─▪ dbt run -m phoenix_events --profile prod --target prod
Running with dbt=0.16.1
Found 48 models, 135 tests, 2 snapshots, 0 analyses, 127 macros, 0 operations, 0 seed files, 9 sources

19:41:48 | Concurrency: 1 threads (target='prod')
19:41:48 |
19:41:48 | 1 of 7 START incremental model public.snowplow_base_event............ [RUN]
19:54:24 | 1 of 7 OK created incremental model public.snowplow_base_event....... [INSERT 0 270057 in 756.00s]
19:54:24 | 2 of 7 START incremental model public.snowplow_payload_event......... [RUN]
19:56:22 | 2 of 7 OK created incremental model public.snowplow_payload_event.... [INSERT 0 282891 in 117.65s]
19:56:22 | 3 of 7 START incremental model public.snowplow_raw_events............ [RUN]
20:00:01 | 3 of 7 OK created incremental model public.snowplow_raw_events....... [INSERT 0 270194 in 219.08s]
20:00:01 | 4 of 7 START incremental model public.snowplow_phoenix_events........ [RUN]
20:03:16 | 4 of 7 OK created incremental model public.snowplow_phoenix_events... [INSERT 0 270057 in 195.10s]
20:03:16 | 5 of 7 START incremental model public.snowplow_sessions.............. [RUN]
06:00:02 | 5 of 7 OK created incremental model public.snowplow_sessions......... [INSERT 0 42168 in 35805.82s]
06:00:02 | 6 of 7 START incremental model public.phoenix_events_combined........ [RUN]
06:10:10 | 6 of 7 ERROR creating incremental model public.phoenix_events_combined [ERROR in 607.92s]
06:10:10 | 7 of 7 START incremental model public.phoenix_sessions_combined...... [RUN]
06:13:49 | 7 of 7 OK created incremental model public.phoenix_sessions_combined. [INSERT 0 14081099 in 219.81s]
06:13:50 |
06:13:50 | Finished running 7 incremental models in 37923.76s.

Completed with 1 error and 0 warnings:

Database Error in model phoenix_events_combined (models/phoenix_events/phoenix_events_combined.sql)
  duplicate key value violates unique constraint "pec_unique"
  DETAIL:  Key (event_datetime, event_name, event_id)=(1970-01-01 02:48:02.705+00, visit, 5cefe3bc14dd3800043c84d3) already exists.
  compiled SQL at ../../docs/run/ds_dbt/phoenix_events/phoenix_events_combined.sql

Done. PASS=6 WARN=0 ERROR=1 SKIP=0 TOTAL=7
```
```
└─▪ dbt run -m phoenix_events.phoenix_events_combined --full-refresh --profile prod --target prod
Running with dbt=0.16.1
Found 48 models, 135 tests, 2 snapshots, 0 analyses, 127 macros, 0 operations, 0 seed files, 9 sources

20:37:34 | Concurrency: 1 threads (target='prod')
20:37:34 |
20:37:34 | 1 of 1 START incremental model public.phoenix_events_combined........ [RUN]
21:42:15 | 1 of 1 OK created incremental model public.phoenix_events_combined... [SELECT 98302511 in 3880.96s]
21:42:15 |
21:42:15 | Finished running 1 incremental model in 3887.93s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
```
└─▪ dbt run -m phoenix_events.phoenix_sessions_combined --full-refresh --profile prod --target prod
Running with dbt=0.16.1
Found 48 models, 135 tests, 2 snapshots, 0 analyses, 127 macros, 0 operations, 0 seed files, 9 sources

21:50:44 | Concurrency: 1 threads (target='prod')
21:50:44 |
21:50:44 | 1 of 1 START incremental model public.phoenix_sessions_combined...... [RUN]
21:51:46 | 1 of 1 OK created incremental model public.phoenix_sessions_combined. [SELECT 23210403 in 62.49s]
21:51:46 |
21:51:46 | Finished running 1 incremental model in 69.19s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/173082160
#### Screenshots (if appropriate)
#### Questions:
```