### PR TITLE
Add causes field

### DIFF
--- a/quasar/dbt/models/users_table/users.sql
+++ b/quasar/dbt/models/users_table/users.sql
@@ -40,7 +40,7 @@ SELECT
 		THEN TRUE ELSE FALSE END AS subscribed_member,
 	umax.max_update AS last_updated_at,
 	u.school_id,
-	(ARRAY(select array_to_string(regexp_matches((u.causes)::TEXT, '([a-zA-Z][^\s,{}"]*)', 'g'), '')))::text AS causes
+	(select STRING_AGG(cause[1], ',') from regexp_matches((u.causes)::TEXT, '([a-zA-Z][^\s,{}"]*)', 'g') AS cause) AS causes
 FROM {{ ref('northstar_users_deduped') }} u
 INNER JOIN
 	(SELECT

--- a/quasar/dbt/models/users_table/users.sql
+++ b/quasar/dbt/models/users_table/users.sql
@@ -40,7 +40,7 @@ SELECT
 		THEN TRUE ELSE FALSE END AS subscribed_member,
 	umax.max_update AS last_updated_at,
 	u.school_id,
-	u.causes
+	(ARRAY(select array_to_string(regexp_matches((u.causes)::TEXT, '([a-zA-Z][^\s,{}"]*)', 'g'), '')))::text AS causes
 FROM {{ ref('northstar_users_deduped') }} u
 INNER JOIN
 	(SELECT

--- a/quasar/dbt/models/users_table/users.sql
+++ b/quasar/dbt/models/users_table/users.sql
@@ -39,7 +39,8 @@ SELECT
 		email_status.event_type = 'customer_subscribed' 
 		THEN TRUE ELSE FALSE END AS subscribed_member,
 	umax.max_update AS last_updated_at,
-	u.school_id
+	u.school_id,
+	u.causes
 FROM {{ ref('northstar_users_deduped') }} u
 INNER JOIN
 	(SELECT


### PR DESCRIPTION
#### What's this PR do?
This PR adds the `causes` field to the `users` table. I'm not 100% sure this format will work, but there's some regex necessary to get this field the way we want because there are two different formats of data in the source table for this field. There's a ticket to update this, so we should clean this up once that gets fixed. 

Here's an example of the different formats in the source data:
```
{"1": "bullying", "4": "gender_rights_equality", "7": "lgbtq_rights_equality", "10": "racial_justice_equity"}
["homelessness_poverty", "gender_rights_equality", "racial_justice_equity", "physical_health"]
```
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
This code will output the `causes` field as text like so:
```
|causes                                                                            
|----------------------------------------------------------------------------------
|{education,mental_health,physical_health}                                         
|{lgbtq_rights_equality,animal_welfare,gender_rights_equality,homelessness_poverty}
|{lgbtq_rights_equality,animal_welfare,gender_rights_equality,homelessness_poverty}
|{lgbtq_rights_equality,animal_welfare,gender_rights_equality,homelessness_poverty}
|{lgbtq_rights_equality,animal_welfare,gender_rights_equality,homelessness_poverty}
|{gender_rights_equality,immigration_refugees,homelessness_poverty,mental_health,racial_justice_equity,physical_health,education,environment,sexual_harassment_assault}
```
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/172065610
#### Screenshots (if appropriate)
#### Questions:
