### PR TITLE
Adding referrer_user_id to users table

### DIFF
--- a/quasar/dbt/models/users_table/northstar_users_raw.sql
+++ b/quasar/dbt/models/users_table/northstar_users_raw.sql
@@ -43,7 +43,8 @@ SELECT
 	nus.dbt_valid_to,
 	nus.google_id,
 	nus.causes::jsonb,
-	nus.school_id
+	nus.school_id,
+	nus.referrer_user_id
 FROM {{ env_var('NORTHSTAR_FT_SCHEMA') }}.northstar_users_snapshot nus
 UNION ALL
 SELECT
@@ -91,5 +92,6 @@ SELECT
 	NULL AS dbt_valid_to,
 	NULL AS google_id,
 	NULL AS causes,
-	nu.school_id
+	nu.school_id,
+	NULL AS referrer_user_id
 FROM {{ source('northstar', 'users') }} nu

--- a/quasar/dbt/models/users_table/users.sql
+++ b/quasar/dbt/models/users_table/users.sql
@@ -40,7 +40,8 @@ SELECT
 		THEN TRUE ELSE FALSE END AS subscribed_member,
 	umax.max_update AS last_updated_at,
 	u.school_id,
-	(select STRING_AGG(cause[1], ',') from regexp_matches((u.causes)::TEXT, '([a-zA-Z][^\s,{}"]*)', 'g') AS cause) AS causes
+	(select STRING_AGG(cause[1], ',') from regexp_matches((u.causes)::TEXT, '([a-zA-Z][^\s,{}"]*)', 'g') AS cause) AS causes,
+	u.referrer_user_id
 FROM {{ ref('northstar_users_deduped') }} u
 INNER JOIN
 	(SELECT

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = convert_deps_to_pip(pfile['packages'], r=False)
 
 setup(
     name="quasar",
-    version="2020.5.17.0",
+    version="2020.6.11.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
This PR adds the 'referrer_user_id` field to the 'users' table. 
#### Where should the reviewer start?
#### How should this be manually tested?
This has been tested on my local against QA, so this field is available in the QA `public.users` table and its parent tables in the `users_table` model.
```
└─▪ dbt run -m users_table --profile qa --target qa
Running with dbt=0.16.1
Found 48 models, 135 tests, 2 snapshots, 0 analyses, 127 macros, 0 operations, 0 seed files, 9 sources

16:13:15 | Concurrency: 1 threads (target='qa')
16:13:15 |
16:13:15 | 1 of 4 START table model public.northstar_users_raw.................. [RUN]
16:25:06 | 1 of 4 OK created table model public.northstar_users_raw............. [SELECT 36325336 in 711.28s]
16:25:06 | 2 of 4 START table model public.cio_latest_status.................... [RUN]
16:26:25 | 2 of 4 OK created table model public.cio_latest_status............... [SELECT 5662377 in 78.84s]
16:26:25 | 3 of 4 START table model public.northstar_users_deduped.............. [RUN]
17:39:15 | 3 of 4 OK created table model public.northstar_users_deduped......... [SELECT 31372459 in 4370.14s]
17:39:15 | 4 of 4 START table model public.users................................ [RUN]
17:48:35 | 4 of 4 OK created table model public.users........................... [SELECT 10971768 in 559.54s]
17:48:35 |
17:48:35 | Finished running 4 table models in 5723.35s.

Completed successfully

Done. PASS=4 WARN=0 ERROR=0 SKIP=0 TOTAL=4
```
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/172804325
#### Screenshots (if appropriate)
#### Questions:
