### PR TITLE
Fixes docs compile error due to bug in sources.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ cd /home/quasar/workspace/"Deploy Branch"/quasar/dbt (for QA) or cd /home/quasar
 pipenv run dbt ARGS
 ```
 
+## Troubleshooting
+
+[TROUBLESHOOTING.md](/docs/troubleshooting.md)
+
 ## Deployment
 
 [DEPLOYMENT.md](/docs/deployment.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,12 @@
 
 ### Running Github Actions locally
 
+We compile docs and publish them [here](https://dosomething.github.io/quasar/#!/overview?g_v=1).
+
+These docs are compiled automatically on every push to our `master`(soon to be called `main`) branch by a [Github Action](https://github.com/DoSomething/quasar/actions).
+
+If you need to test the action locally you can do so following the next steps:
+
 - Install [act](https://github.com/nektos/act). Instructions in the link.
 - Create an `.env` file with the necessary variables to run the docs compile. See LastPass and look at the [workflow job code](../.github/workflows/dbt-docs.yml) for guidance.
 - Locally updating the Github workflow job to get ENV variables from the `env.` context instead of the default `secrets.` context.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,14 @@
+## Troubleshooting
+
+### Running Github Actions locally
+
+- Install [act](https://github.com/nektos/act). Instructions in the link.
+- Create an `.env` file with the necessary variables to run the docs compile. See LastPass and look at the [workflow job code](../.github/workflows/dbt-docs.yml) for guidance.
+- Locally updating the Github workflow job to get ENV variables from the `env.` context instead of the default `secrets.` context.
+    - Example: `PG_DOCS_HOST: ${{ secrets.PG_DOCS_HOST }} -> PG_DOCS_HOST: ${{ env.PG_DOCS_HOST }}`.
+- Manually pass the image to use for `Ubuntu-latest` due to a [bug](https://github.com/nektos/act/issues/251#issuecomment-633457052) in the library and the env variables.
+    - `ubuntu-latest=nektos/act-environments-ubuntu:18.04`
+
+#### Usage
+
+Run: `act -vP ubuntu-latest=nektos/act-environments-ubuntu:18.04 --env-file ~/.dbt/prod.env`

--- a/quasar/dbt/models/sources.yml
+++ b/quasar/dbt/models/sources.yml
@@ -23,7 +23,7 @@ sources:
       - name: campaign_info_ashes_snapshot
 
   - name: public_intermediate
-    schema: public_intermediates
+    schema: public_intermediate
     tables:
       - name: contentful_metadata
 

--- a/quasar/dbt/models/sources.yml
+++ b/quasar/dbt/models/sources.yml
@@ -20,10 +20,10 @@ sources:
     # once we move this table to the right schema
     schema: public
     tables:
-      - name: '{{ env_var("CAMPAIGN_INFO_ASHES_SNAPSHOT") }}'
+      - name: campaign_info_ashes_snapshot
 
   - name: public_intermediate
-    schema: public_intermediate
+    schema: public_intermediates
     tables:
       - name: contentful_metadata
 


### PR DESCRIPTION
#### What's this PR do?
- Fixes doc compile error due to interpolating a source table name. Seems like it's only allowed for the schema.
#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/172978270

#### Troubleshooting

I had to run the Github action job locally to troubleshoot the error. I used this tool: [act](https://github.com/nektos/act).
After a lot of trial and error:
- create an env file with the necessary ENV variables to run the docs compile 
- locally updating the Github workflow job to get ENV variables from the `env.` context instead of the default `secrets.` context, e.g. `PG_DOCS_HOST: ${{ secrets.PG_DOCS_HOST }} -> PG_DOCS_HOST: ${{ env.PG_DOCS_HOST }}`.
- Had to manually pass the image to use for `Ubuntu-latest` due to a [bug](https://github.com/nektos/act/issues/251#issuecomment-633457052) in the library and the env variables.

This is the command I used: `act -vP ubuntu-latest=nektos/act-environments-ubuntu:18.04 --env-file ~/.dbt/prod.env`