### PR TITLE
Adds cio_historical source

### DIFF
--- a/quasar/dbt/models/cio/cio_customer_event.sql
+++ b/quasar/dbt/models/cio/cio_customer_event.sql
@@ -33,7 +33,7 @@ SELECT
     NULL AS cio_campaign_name,
     NULL AS cio_campaign_type
 FROM
-    {{ source('cio_historical', 'customer_event') }} cceo
+    {{ source('cio_historical', 'cio_customer_event') }} cceo
 WHERE
     -- Date we re-started saving raw C.io events to the event_log table
     "timestamp" < '2020-04-01'

--- a/quasar/dbt/models/cio/cio_customer_event.sql
+++ b/quasar/dbt/models/cio/cio_customer_event.sql
@@ -33,7 +33,7 @@ SELECT
     NULL AS cio_campaign_name,
     NULL AS cio_campaign_type
 FROM
-    {{ source('cio', 'customer_event_old') }} cceo
+    {{ source('cio_historical', 'customer_event') }} cceo
 WHERE
     -- Date we re-started saving raw C.io events to the event_log table
     "timestamp" < '2020-04-01'

--- a/quasar/dbt/models/cio/cio_email_bounced_event.sql
+++ b/quasar/dbt/models/cio/cio_email_bounced_event.sql
@@ -27,7 +27,7 @@ SELECT
     "timestamp",
     NULL AS cio_campaign_id,
     NULL AS cio_campaign_name
-FROM {{ source('cio', 'email_bounced_old') }}
+FROM {{ source('cio_historical', 'email_bounced') }}
 WHERE
     -- Date we re-started saving raw C.io events to the event_log table
     "timestamp" < '2020-04-01'

--- a/quasar/dbt/models/cio/cio_email_bounced_event.sql
+++ b/quasar/dbt/models/cio/cio_email_bounced_event.sql
@@ -27,7 +27,7 @@ SELECT
     "timestamp",
     NULL AS cio_campaign_id,
     NULL AS cio_campaign_name
-FROM {{ source('cio_historical', 'email_bounced') }}
+FROM {{ source('cio_historical', 'cio_email_bounced') }}
 WHERE
     -- Date we re-started saving raw C.io events to the event_log table
     "timestamp" < '2020-04-01'

--- a/quasar/dbt/models/cio/cio_email_event.sql
+++ b/quasar/dbt/models/cio/cio_email_event.sql
@@ -35,7 +35,7 @@ SELECT
     NULL AS cio_campaign_id,
     NULL AS cio_campaign_name,
     NULL AS cio_campaign_type
-FROM {{ source('cio_historical', 'email_event') }}
+FROM {{ source('cio_historical', 'cio_email_event') }}
 WHERE
     -- Date we re-started saving raw C.io events to the event_log table
     "timestamp" < '2020-04-01'

--- a/quasar/dbt/models/cio/cio_email_event.sql
+++ b/quasar/dbt/models/cio/cio_email_event.sql
@@ -35,7 +35,7 @@ SELECT
     NULL AS cio_campaign_id,
     NULL AS cio_campaign_name,
     NULL AS cio_campaign_type
-FROM {{ source('cio', 'email_event_old') }}
+FROM {{ source('cio_historical', 'email_event') }}
 WHERE
     -- Date we re-started saving raw C.io events to the event_log table
     "timestamp" < '2020-04-01'

--- a/quasar/dbt/models/cio/cio_email_sent_event.sql
+++ b/quasar/dbt/models/cio/cio_email_sent_event.sql
@@ -33,7 +33,7 @@ SELECT
     NULL AS cio_campaign_name,
     NULL AS cio_campaign_type
 FROM
-    {{ source('cio_historical', 'email_sent') }} ceso
+    {{ source('cio_historical', 'cio_email_sent') }} ceso
 WHERE
     -- Date we re-started saving raw C.io events to the event_log table
     "timestamp" < '2020-04-01'

--- a/quasar/dbt/models/cio/cio_email_sent_event.sql
+++ b/quasar/dbt/models/cio/cio_email_sent_event.sql
@@ -33,7 +33,7 @@ SELECT
     NULL AS cio_campaign_name,
     NULL AS cio_campaign_type
 FROM
-    {{ source('cio', 'email_sent_old') }} ceso
+    {{ source('cio_historical', 'email_sent') }} ceso
 WHERE
     -- Date we re-started saving raw C.io events to the event_log table
     "timestamp" < '2020-04-01'

--- a/quasar/dbt/models/sources.yml
+++ b/quasar/dbt/models/sources.yml
@@ -31,10 +31,14 @@ sources:
     schema: '{{ env_var("CIO_WEBHOOK_EVENTS_SCHEMA") }}'
     tables:
       - name: event_log
-      - name: customer_event_old
-      - name: email_sent_old
-      - name: email_bounced_old
-      - name: email_event_old
+
+  - name: cio_historical
+    schema: '{{ env_var("HISTORICAL_ANALYTICS_SCHEMA") }}'
+    tables:
+      - name: customer_event
+      - name: email_sent
+      - name: email_bounced
+      - name: email_event
 
   - name: gambit
     schema: '{{ env_var("FT_GAMBIT") }}'

--- a/quasar/dbt/models/sources.yml
+++ b/quasar/dbt/models/sources.yml
@@ -35,10 +35,10 @@ sources:
   - name: cio_historical
     schema: '{{ env_var("HISTORICAL_ANALYTICS_SCHEMA") }}'
     tables:
-      - name: customer_event
-      - name: email_sent
-      - name: email_bounced
-      - name: email_event
+      - name: cio_customer_event
+      - name: cio_email_sent
+      - name: cio_email_bounced
+      - name: cio_email_event
 
   - name: gambit
     schema: '{{ env_var("FT_GAMBIT") }}'


### PR DESCRIPTION
#### What's this PR do?
- Updates the source naming for old Cio snapshot tables ahead of moving them to the `historical_analytics` schema.

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/172923044

#### todo
- [ ] Migrate old Cio tables to `historical_analytics` schema