### PR TITLE
Adding referrer_user_id to public.signups

### DIFF
--- a/quasar/dbt/models/campaign_activity/signups.sql
+++ b/quasar/dbt/models/campaign_activity/signups.sql
@@ -6,6 +6,7 @@ SELECT
     sd.why_participated AS why_participated,
     sd."source" AS "source",
     sd.details,
+    sd.referrer_user_id,
 	CASE WHEN sd."source" = 'niche' THEN 'niche'
 	     WHEN sd."source" ilike '%sms%' THEN 'sms'
 	     WHEN sd."source" in ('rock-the-vote', 'turbovote') THEN 'voter-reg'


### PR DESCRIPTION
#### What's this PR do?
This PR adds the `referrer_user_id` field to the `public.signups` table
#### Where should the reviewer start?
#### How should this be manually tested?
I've manually tested rebuilding against the `qa_prod_dump` schema
```
└─▪ dbt run -m campaign_activity.signups --profile qa_prod --target qa_prod
Running with dbt=0.16.1
Found 48 models, 135 tests, 2 snapshots, 0 analyses, 127 macros, 0 operations, 0 seed files, 23 sources

11:38:37 | Concurrency: 1 threads (target='qa_prod')
11:38:37 |
11:38:37 | 1 of 1 START table model public.signups.............................. [RUN]
11:39:27 | 1 of 1 OK created table model public.signups......................... [SELECT 11796893 in 50.58s]
11:39:27 |
11:39:27 | Finished running 1 table model in 52.85s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/173573654
#### Screenshots (if appropriate)
#### Questions:
