### PR TITLE
Adding group related tables and fields

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -378,6 +378,18 @@ models:
             - "CREATE INDEX ON {{ this }}(northstar_id, device_id, journey_begin_ts)"
             - "GRANT SELECT ON {{ this }} to dsanalyst"
             - "GRANT SELECT ON {{ this }} to looker"
+        groups:
+          alias: groups
+          materialized: table
+          post-hook:
+            - "GRANT SELECT ON {{ this }} to dsanalyst"
+            - "GRANT SELECT ON {{ this }} to looker"
+        group_types:
+          alias: group_types
+          materialized: table
+          post-hook:
+            - "GRANT SELECT ON {{ this }} to dsanalyst"
+            - "GRANT SELECT ON {{ this }} to looker"
       cio:
         cio_customer_event:
           materialized: table

--- a/quasar/dbt/models/campaign_activity/first_and_second_signups.sql
+++ b/quasar/dbt/models/campaign_activity/first_and_second_signups.sql
@@ -20,6 +20,7 @@ WITH ns_signups AS (
         campaign_id,
         source_bucket,
         created_at,
+        group_id,
         rank() over(
             PARTITION by northstar_id
             ORDER BY

--- a/quasar/dbt/models/campaign_activity/posts.sql
+++ b/quasar/dbt/models/campaign_activity/posts.sql
@@ -51,6 +51,7 @@ SELECT
 	a.civic_action,
 	a.scholarship_entry,
 	pd.school_id,
+	pd.group_id,
 	CASE 
 		WHEN rtv.tracking_source='ads' THEN 'ads'
 		ELSE split_part(substring(rtv.tracking_source from 'source\:(.+)'), ',', 1) 

--- a/quasar/dbt/models/campaign_activity/reportbacks.sql
+++ b/quasar/dbt/models/campaign_activity/reportbacks.sql
@@ -17,6 +17,7 @@ SELECT
     pd.postal_code,
     pd.vr_source,
     pd.vr_source_details,
+    pd.group_id,
     CASE
         WHEN (pd.post_class ilike '%vote%' AND pd.status = 'confirmed')
         THEN 'self-reported registrations'

--- a/quasar/dbt/models/campaign_activity/signups.sql
+++ b/quasar/dbt/models/campaign_activity/signups.sql
@@ -7,6 +7,7 @@ SELECT
     sd."source" AS "source",
     sd.details,
     sd.referrer_user_id,
+    sd.group_id,
 	CASE WHEN sd."source" = 'niche' THEN 'niche'
 	     WHEN sd."source" ilike '%sms%' THEN 'sms'
 	     WHEN sd."source" in ('rock-the-vote', 'turbovote') THEN 'voter-reg'

--- a/quasar/dbt/models/campaign_info/campaign_info.sql
+++ b/quasar/dbt/models/campaign_info/campaign_info.sql
@@ -77,6 +77,7 @@ SELECT
 	c.end_date AS campaign_run_end_date,
 	c.created_at AS campaign_created_date,
 	COALESCE(i.campaign_node_id, c.id) AS campaign_node_id,
+  c.group_type_id,
   cm.contentful_id as contentful_id,
   cm.internal_title as contentful_internal_title,
   cm.title as contentful_title,

--- a/quasar/dbt/models/schema.md
+++ b/quasar/dbt/models/schema.md
@@ -822,3 +822,23 @@ Submitted the quiz, and then registered to vote
 {% docs comparison_patterns %}
 Pattern e.g. (Both are Unknown, One is Unknown, Same, Different)
 {% enddocs %}
+
+{% docs group_type_id %}
+Group type id is....
+{% enddocs %}
+
+{% docs external_id %}
+External id is....
+{% enddocs %}
+
+{% docs filter_by_state %}
+Filter by state is....
+{% enddocs %}
+
+{% docs goal %}
+The goal of the group
+{% enddocs %}
+
+{% docs group_name %}
+The name of the group
+{% enddocs %}

--- a/quasar/dbt/models/sources.yml
+++ b/quasar/dbt/models/sources.yml
@@ -14,6 +14,8 @@ sources:
       - name: posts
       - name: signups
       - name: campaigns
+      - name: groups
+      - name: group_types
 
   - name: campaign_info_historical
     # TODO: switch to '{{ env_var("HISTORICAL_ANALYTICS_SCHEMA") }}'

--- a/quasar/dbt/models/voter_reg/group_types.sql
+++ b/quasar/dbt/models/voter_reg/group_types.sql
@@ -1,0 +1,7 @@
+SELECT
+	id,
+	"name",
+	created_at,
+	updated_at,
+	filter_by_state
+FROM {{ source('rogue', 'group_types') }}

--- a/quasar/dbt/models/voter_reg/groups.sql
+++ b/quasar/dbt/models/voter_reg/groups.sql
@@ -1,0 +1,12 @@
+SELECT
+	id,
+	group_type_id,
+	"name",
+	goal,
+	created_at,
+	updated_at,
+	city,
+	external_id,
+	state,
+	school_id
+FROM {{ source('rogue', 'groups') }}

--- a/quasar/dbt/models/voter_reg/schema.yml
+++ b/quasar/dbt/models/voter_reg/schema.yml
@@ -58,3 +58,56 @@ models:
 
         - name: submit_quiz_register_affirmation
           description: '{{ doc("submit_quiz_register_affirmation") }}'
+
+  - name: group
+    description: Needs a description
+
+    columns:
+        - name: id
+          description: '{{ doc("northstar_id") }}'
+
+        - name: group_type_id
+          description: '{{ doc("group_type_id") }}'
+
+        - name: name
+          description: '{{ doc("group_name") }}'
+
+        - name: goal
+          description: '{{ doc("goal") }}'
+
+        - name: created_at
+          description: '{{ doc("created_at") }}'
+
+        - name: updated_at
+          description: '{{ doc("updated_at") }}'
+
+        - name: city
+          description: '{{ doc("city") }}'
+
+        - name: external_id
+          description: '{{ doc("external_id") }}'
+
+        - name: state
+          description: '{{ doc("state") }}'
+
+        - name: school_id
+          description: '{{ doc("school_id") }}'
+
+  - name: group_types
+    description: Needs a description
+
+    columns:
+        - name: id
+          description: '{{ doc("northstar_id") }}'
+
+        - name: name
+          description: '{{ doc("group_name") }}'
+
+        - name: created_at
+          description: '{{ doc("created_at") }}'
+
+        - name: updated_at
+          description: '{{ doc("updated_at") }}'
+
+        - name: filter_by_state
+          description: '{{ doc("filter_by_state") }}'


### PR DESCRIPTION
#### What's this PR do?
This PR:
  * adds the `groups` and `group_types` tables from Rogue Fivetran
  * adds `group_type_id` field to the `campaigns` table
  * adds `group_id` field to `signups` and `posts`
  * adds `group_id` field to downstream tables, `reportbacks` and `campaign_info`
  * adds placeholders for documentation of new fields
#### Where should the reviewer start?
#### How should this be manually tested?
Tested successfully from my local against QA:
```
─▪ dbt run -m voter_reg --profile qa --target qa
Running with dbt=0.16.1
Found 51 models, 135 tests, 2 snapshots, 0 analyses, 127 macros, 0 operations, 0 seed files, 25 sources

16:54:48 | Concurrency: 1 threads (target='qa')
16:54:48 |
16:54:48 | 1 of 3 START table model public.group_types.......................... [RUN]
16:54:49 | 1 of 3 OK created table model public.group_types..................... [SELECT 7 in 0.56s]
16:54:49 | 2 of 3 START table model public.groups............................... [RUN]
16:54:49 | 2 of 3 OK created table model public.groups.......................... [SELECT 29889 in 0.38s]
16:54:49 | 3 of 3 START table model public.voter_reg_quiz_funnel................ [RUN]
16:58:00 | 3 of 3 OK created table model public.voter_reg_quiz_funnel........... [SELECT 111343 in 190.79s]
16:58:00 |
16:58:00 | Finished running 3 table models in 197.54s.

Completed successfully

Done. PASS=3 WARN=0 ERROR=0 SKIP=0 TOTAL=3

└─▪ dbt run -m campaign_activity --profile qa --target qa
Running with dbt=0.16.1
Found 51 models, 135 tests, 2 snapshots, 0 analyses, 127 macros, 0 operations, 0 seed files, 25 sources

16:58:28 | Concurrency: 1 threads (target='qa')
16:58:28 |
16:58:28 | 1 of 7 START table model public.rock_the_vote........................ [RUN]
16:58:37 | 1 of 7 OK created table model public.rock_the_vote................... [SELECT 425531 in 8.50s]
16:58:37 | 2 of 7 START table model public.signups.............................. [RUN]
16:59:29 | 2 of 7 OK created table model public.signups......................... [SELECT 12145985 in 52.13s]
16:59:29 | 3 of 7 START table model public.turbovote............................ [RUN]
16:59:33 | 3 of 7 OK created table model public.turbovote....................... [SELECT 27758 in 3.87s]
16:59:33 | 4 of 7 START table model public.device_campaign...................... [RUN]
17:03:44 | 4 of 7 OK created table model public.device_campaign................. [SELECT 6058661 in 251.21s]
17:03:44 | 5 of 7 START table model public.posts................................ [RUN]
17:04:24 | 5 of 7 OK created table model public.posts........................... [SELECT 1818199 in 40.30s]
17:04:24 | 6 of 7 START table model public.reportbacks.......................... [RUN]
17:04:36 | 6 of 7 OK created table model public.reportbacks..................... [SELECT 1137151 in 11.73s]
17:04:36 | 7 of 7 START table model public.first_and_second_signups............. [RUN]
17:07:34 | 7 of 7 OK created table model public.first_and_second_signups........ [SELECT 5610711 in 177.55s]
17:07:34 |
17:07:34 | Finished running 7 table models in 547.66s.

Completed successfully

Done. PASS=7 WARN=0 ERROR=0 SKIP=0 TOTAL=7
```
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/173293771
#### Screenshots (if appropriate)
#### Questions:
