### PR TITLE
Updating raw bertly clicks table reference

### DIFF
--- a/quasar/etl_monitoring.py
+++ b/quasar/etl_monitoring.py
@@ -65,7 +65,7 @@ class ETLMonitoring:
             'raw_cio_customers':
                 'SELECT count(*) FROM public.cio_customer_event',
             'raw_bertly_clicks':
-                'SELECT count(*) FROM bertly.clicks',
+                'SELECT count(*) FROM ft_bertly.clicks',
             'raw_gambit_messages':
                 """SELECT count(*) FROM ft_gambit_conversations_api.messages""",
             'raw_gambit_conversations':


### PR DESCRIPTION
#### What's this PR do?
This PR updates the raw bertly clicks table name to point to Fivetran. The wrong table name is causing ETL monitoring to fail. I'd like to refactor this so that we don't have to constantly update these table names, but that can be done in another ticket as part of the monitoring work. 

https://jenkins.d12g.co/job/ETL%20Monitoring/1276/console
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/174166818
#### Screenshots (if appropriate)
#### Questions:
