### PR TITLE
Readding group_id to reportbacks

### DIFF
--- a/quasar/dbt/models/campaign_activity/reportbacks.sql
+++ b/quasar/dbt/models/campaign_activity/reportbacks.sql
@@ -31,6 +31,7 @@ SELECT pd.northstar_id,
        pd.postal_code,
        pd.vr_source,
        pd.vr_source_details,
+       pd.group_id,
        CASE
            WHEN (pd.post_class ILIKE '%vote%'
                  AND pd.status = 'confirmed') THEN 'self-reported registrations'


### PR DESCRIPTION
#### What's this PR do?
This PR readds the `group_id` field to the `reportbacks` table. Looks like it was removed during this update to the reportbacks table. https://github.com/DoSomething/quasar/commit/c97aec9b24d0976f90c89e36b2b489b61da3bb0d
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/174213174
#### Screenshots (if appropriate)
#### Questions:
