### PR TITLE
Using env vars for dump tables

### DIFF
--- a/quasar/prod_to_qa.py
+++ b/quasar/prod_to_qa.py
@@ -21,11 +21,9 @@ prod_pg_opts = {
 
 
 def main():
-    schemas = ["analyst_sandbox", "bertly", "cio", "dosomething",
-               "ft_dosomething_rogue", "ft_gambit_conversations_api",
-               "ft_snowplow", "northstar_ft_userapi", "public"]
+    schemas = os.getenv('DUMP_SCHEMAS')
 
-    for schema in schemas:
+    for schema in schemas.split(" "):
         psql(pg_dump(
             '-h', prod_pg_opts['host'],
             '-U', prod_pg_opts['username'],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = convert_deps_to_pip(pfile['packages'], r=False)
 
 setup(
     name="quasar",
-    version="2020.8.14.0",
+    version="2020.8.14.1",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
#### What's this PR do?
This PR updates the QA dump to use an ENV var so that it's easier to update when we want to update the schemas that get dumped from prod into QA. Unfortunately `pg_dump` doesn't have a `CASCADE` option with the `--clean` flag so I'll need to play around a bit with the order of the schemas that get dumped. The alternative is to delete the entire schema, but since we use it as a sandbox, I'd rather not delete things that we're working on that are in progress. 

I've set up the variable in QA:
```
export DUMP_SCHEMAS='public analyst_sandbox bertly cio dosomething ft_dosomething_rogue ft_gambit_conversations_api ft_snowplow ft_snowplow_20200813 northstar_ft_userapi tmc_in tmc_out fivetran_log' 
```

#### Where should the reviewer start?
#### How should this be manually tested?
I've manually tested this locally with `fivetran_log` and `dump_test_schema` (which I've now removed)
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/173799048
#### Screenshots (if appropriate)
#### Questions:
