### PR TITLE
Removing unique indexes from funnels

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -398,7 +398,6 @@ models:
           alias: ovrd_creator_funnel
           materialized: table
           post-hook:
-            - "CREATE UNIQUE INDEX {{ get_index_name(this, 'unique_northstar_id_device_id') }} (northstar_id, device_id)"
             - "CREATE INDEX {{ get_index_name(this, 'northstar_id') }} (northstar_id)"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"
             - "GRANT SELECT ON {{ this }} TO looker"
@@ -406,7 +405,6 @@ models:
           alias: ovrd_group_creator_funnel
           materialized: table
           post-hook:
-            - "CREATE UNIQUE INDEX {{ get_index_name(this, 'unique_northstar_id_device_id') }} (northstar_id, device_id)"
             - "CREATE INDEX {{ get_index_name(this, 'northstar_id') }} (northstar_id)"
             - "GRANT SELECT ON {{ this }} TO dsanalyst"
             - "GRANT SELECT ON {{ this }} TO looker"


### PR DESCRIPTION
#### What's this PR do?
This PR removes the unique indexes for the OVRD funnels since the funnels no longer have unique Northstar ID's.
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/174177914
#### Screenshots (if appropriate)
#### Questions:
