### PR TITLE
Fixes missing event_name column in snowplow_payload_event model

### DIFF
--- a/quasar/dbt/models/phoenix_events/schema.yml
+++ b/quasar/dbt/models/phoenix_events/schema.yml
@@ -95,6 +95,8 @@ models:
                 severity: warn
             - not_null:
                 severity: warn
+        - name: event_name
+          description: '{{ doc("event_name") }}'
         - name: ft_timestamp
           description: '[Required] {{ doc("event_datetime") }}'
           tests:

--- a/quasar/dbt/models/phoenix_events/snowplow_payload_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_payload_event.sql
@@ -1,5 +1,6 @@
 SELECT
     event_id,
+    payload::jsonb #>> '{name}' AS event_name,
     payload::jsonb #>> '{utmSource}' AS utm_source,
     payload::jsonb #>> '{utmMedium}' AS utm_medium,
     payload::jsonb #>> '{utmCampaign}' AS utm_campaign,


### PR DESCRIPTION
#### What's this PR do?
Fixes missing `event_name` column that was breaking a `not_null_where` schema test.

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/174756983
