### PR TITLE
Parses URL encoded %3A user NSID from the click target_url

### DIFF
--- a/quasar/dbt/models/bertly/bertly_clicks.sql
+++ b/quasar/dbt/models/bertly/bertly_clicks.sql
@@ -4,7 +4,8 @@ SELECT
         (regexp_split_to_array(
             (regexp_split_to_array(
                 c.target_url, 'user')
-            )[2], E'[=:]+')
+            -- %3A is the URI Encoded triplet that represents the character ":"
+            )[2], E'[=:]+|%3A')
         )[2],
         E'[^a-zA-Z0-9]')
     )[1] AS northstar_id,


### PR DESCRIPTION
#### What's this PR do?
- Fixes parsing of URL encoded Northstar ids in Bertly (URL shortener) clicks 
#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/174300462

