### PR TITLE
Points snowplow DBT models to build from legacy ft_snowplow schema

### DIFF
--- a/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_base_event.sql
@@ -55,14 +55,14 @@ SELECT
     refr_urlpath AS referrer_path,
     refr_source AS referrer_source
 FROM
-  {{ ref('ft_snowplow_events_20200813') }}
+  {{ source('snowplow', 'event') }}
 WHERE
   event_id NOT IN
 (
   SELECT
     event_id
   FROM
-    {{ ref('ft_snowplow_ua_parser_context_20200813') }} u
+    {{ source('snowplow', 'ua_parser_context') }} u
   WHERE
     u.useragent_family SIMILAR TO '%(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|YandexBot|Twitterbot|a_archiver|facebookexternalhit|Bingbot|Googlebot|Baiduspider|360(Spider|User-agent)|Ghost)%'
 )

--- a/quasar/dbt/models/phoenix_events/snowplow_payload_event.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_payload_event.sql
@@ -14,7 +14,7 @@ SELECT
     payload::jsonb #>> '{contextSource}' AS context_source,
     payload::jsonb #>> '{value}' AS context_value,
     _fivetran_synced AS ft_timestamp
-FROM {{ ref('ft_snowplow_payloads_20200813') }}
+FROM {{ source('snowplow', 'snowplow_event') }}
 
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run


### PR DESCRIPTION
#### What's this PR do?
- Points our Snowplow events and payload models to source the raw data from the `ft_snowplow` schema.

```
pipenv run dbt run --full-refresh --models phoenix_events.snowplow_base_event phoenix_events.snowplow_payload_event --profile qa
Running with dbt=0.16.1
Found 56 models, 90 tests, 3 snapshots, 0 analyses, 130 macros, 0 operations, 0 seed files, 28 sources

14:24:02 | Concurrency: 4 threads (target='default')
14:24:02 | 
14:24:02 | 1 of 2 START incremental model public.snowplow_base_event............ [RUN]
14:24:02 | 2 of 2 START incremental model public.snowplow_payload_event......... [RUN]
14:24:05 | 2 of 2 OK created incremental model public.snowplow_payload_event.... [SELECT 174749 in 2.96s]
14:24:05 | 1 of 2 OK created incremental model public.snowplow_base_event....... [SELECT 195553 in 3.28s]
14:24:05 | 
14:24:05 | Finished running 2 incremental models in 8.33s.

Completed successfully

Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
```

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/174887199
