### PR TITLE
Adds signup ranking to campaign_activity.signups model

### DIFF
--- a/quasar/dbt/models/campaign_activity/signups.sql
+++ b/quasar/dbt/models/campaign_activity/signups.sql
@@ -1,33 +1,46 @@
 SELECT
-    sd.northstar_id AS northstar_id,
-    sd.id AS id,
-    sd.campaign_id AS campaign_id,
-    sd.campaign_run_id AS campaign_run_id,
-    sd.why_participated AS why_participated,
-    sd."source" AS "source",
-    sd.details,
-    sd.referrer_user_id,
-    sd.group_id,
-	CASE WHEN sd."source" = 'niche' THEN 'niche'
-	     WHEN sd."source" ilike '%sms%' THEN 'sms'
-	     WHEN sd."source" in ('rock-the-vote', 'turbovote') THEN 'voter-reg'
-	     ELSE 'web' END AS source_bucket,
-    sd.created_at AS created_at,
-    sd.source_details,
-    CASE 
-		WHEN source_details ILIKE '%\}'
-		THEN (CAST(source_details as json) ->> 'utm_medium') 
-		ELSE NULL END AS utm_medium,
-	CASE 
-		WHEN source_details ILIKE '%\}'
-		THEN (CAST(source_details as json) ->> 'utm_source')
-		ELSE NULL END AS utm_source,
-	CASE 
-		WHEN source_details ILIKE '%\}'
-		THEN (CAST(source_details as json) ->> 'utm_campaign')
-		ELSE NULL END AS utm_campaign
-FROM {{ source('rogue', 'signups') }} sd
-WHERE sd._fivetran_deleted = 'false'
-AND sd.deleted_at IS NULL
-AND sd."source" IS DISTINCT FROM 'rogue-oauth'
-AND sd.why_participated IS DISTINCT FROM 'Testing from Ghost Inspector!'
+	sd.northstar_id AS northstar_id,
+	sd.id AS id,
+	sd.campaign_id AS campaign_id,
+	sd.campaign_run_id AS campaign_run_id,
+	sd.why_participated AS why_participated,
+	sd."source" AS "source",
+	sd.details,
+	sd.referrer_user_id,
+	sd.group_id,
+	CASE
+		WHEN sd."source" = 'niche' THEN 'niche'
+		WHEN sd."source" ilike '%sms%' THEN 'sms'
+		WHEN sd."source" IN ('rock-the-vote', 'turbovote') THEN 'voter-reg'
+		ELSE 'web'
+	END AS source_bucket,
+	sd.created_at AS created_at,
+	sd.source_details,
+	CASE
+		WHEN source_details ILIKE '%\}' THEN (CAST(source_details AS json) ->> 'utm_medium')
+		ELSE NULL
+	END AS utm_medium,
+	CASE
+		WHEN source_details ILIKE '%\}' THEN (CAST(source_details AS json) ->> 'utm_source')
+		ELSE NULL
+	END AS utm_source,
+	CASE
+		WHEN source_details ILIKE '%\}' THEN (CAST(source_details AS json) ->> 'utm_campaign')
+		ELSE NULL
+	END AS utm_campaign,
+	rank() OVER (
+		PARTITION BY sd.northstar_id
+		ORDER BY
+			sd.created_at
+	) AS signup_rank
+FROM
+	{{ source('rogue', 'signups') }} sd
+WHERE
+	sd._fivetran_deleted = 'false'
+	AND sd.deleted_at IS NULL
+	AND sd."source" IS DISTINCT
+FROM
+	'rogue-oauth'
+	-- We're using full text search to find all non test signups
+	-- This column is using a GIN index (manually created on Prod) to speed up the query
+	AND to_tsvector('english', sd.why_participated) @@ to_tsquery('!inspector & !test & !ghost')


### PR DESCRIPTION
It took a little while to get the performance right for this model. I had to add a GIN Index to store a Full Text searchable index of `why_participated`. This was to offset the performance hit from the `rank()` window function.

Command used to create the index:

```
CREATE INDEX concurrently signups_why_p_tsvector_idx ON ft_dosomething_rogue.signups using gin (to_tsvector('english', why_participated));
```

#### What's this PR do?
- Adds ranking to `campaign_activity.signups` model

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/174626781

