### PR TITLE
Schema tests for snowplow phoenix events model 

### DIFF
--- a/quasar/dbt/models/phoenix_events/schema.yml
+++ b/quasar/dbt/models/phoenix_events/schema.yml
@@ -126,111 +126,111 @@ models:
   - name: snowplow_raw_events
     description: Table combining snowplow_base_event and snowplow_payload_event into rich raw data source for all clickstream info
     columns:
-        - name: block_id
-          description: '{{ doc("block_id") }}'
-        - name: browser_size
-          description: '{{ doc("browser_size") }}'
-        - name: campaign_id
-          description: '{{ doc("internal_campaign_id") }}'
-        - name: clicked_link_url
-          description: '{{ doc("click_event_url") }}'
-        - name: context_source
-          description: '{{ doc("context_source") }}'
-        - name: context_value
-          description: '{{ doc("context_value") }}'
-        - name: device_id
-          description: '[Required] {{ doc("device_id") }}'
-          tests:
-            - not_null:
-                severity: warn
-        - name: event_datetime
-          description: '{{ doc("event_datetime") }}'
-        - name: event_datetime
-          description: '[Required] {{ doc("event_datetime") }}'
-          tests:
-            - not_null:
-                severity: warn
-        - name: event_id
-          description: '[Required] {{ doc("event_id") }}'
-          tests:
-            - unique:
-                severity: warn
-            - not_null:
-                severity: warn
-        - name: event_name
-          description: '{{ doc("event_name") }}'
-        - name: event_source
-          description: '[Required] {{ doc("event_source") }}'
-          tests:
-            - not_null:
-                severity: warn
-        - name: event_type
-          description: '[Required] {{ doc("event_type") }}'
-          tests:
-            - not_null:
-                severity: warn
-        - name: group_id
-          description: '{{ doc("group_id") }}'
-        - name: host
-          description: '[Required] {{ doc("host") }}'
-          tests:
-            - not_null:
-                severity: warn
-        - name: modal_type
-          description: '[Required conditionally] {{ doc("modal_type") }}'
-          tests:
-            - not_null_where:
-                condition: "event_name similar to '%(opened_modal|closed_modal)%'"
-                severity: warn
-        - name: northstar_id
-          description: '{{ doc("northstar_id") }}'
-        - name: page_id
-          description: '{{ doc("page_id") }}'
-        - name: path
-          description: '[Required] {{ doc("path") }}'
-          tests:
-            - not_null:
-                severity: warn
-        - name: query_parameters
-          description: '{{ doc("query_parameters") }}'
-        - name: referrer_host
-          description: '{{ doc("referrer_host") }}'
-        - name: referrer_path
-          description: '{{ doc("referrer_path") }}'
-        - name: referrer_source
-          description: '{{ doc("referrer_source") }}'
-        - name: se_action
-          description: '[Required conditionally] {{ doc("se_action") }}'
-          tests:
-            - not_null_where:
-                condition: "event_type = 'se'"
-                severity: warn
-        - name: se_category
-          description: '[Required conditionally] {{ doc("se_category") }}'
-          tests:
-            - not_null_where:
-                condition: "event_type = 'se'"
-                severity: warn
-        - name: se_label
-          description: '{{ doc("se_label") }}'
-        - name: search_query
-          description: '{{ doc("search_query") }}'
-        - name: session_counter
-          description: '[Required] {{ doc("session_counter") }}'
-          tests:
-            - not_null:
-                severity: warn
-        - name: session_id
-          description: '[Required] {{ doc("session_id") }}'
-          tests:
-            - not_null:
-                severity: warn
-        - name: utm_campaign
-          description: '{{ doc("utm_campaign") }}'
-        - name: utm_medium
-          description: '{{ doc("utm_medium") }}'
-        - name: utm_source
-          description: '{{ doc("utm_source") }}'
+      - name: block_id
+        description: '{{ doc("block_id") }}'
+      - name: browser_size
+        description: '{{ doc("browser_size") }}'
+      - name: campaign_id
+        description: '{{ doc("internal_campaign_id") }}'
+      - name: clicked_link_url
+        description: '{{ doc("click_event_url") }}'
+      - name: context_source
+        description: '{{ doc("context_source") }}'
+      - name: context_value
+        description: '{{ doc("context_value") }}'
+      - name: device_id
+        description: '[Required] {{ doc("device_id") }}'
+        tests:
+          - not_null:
+              severity: warn
+      - name: event_datetime
+        description: '{{ doc("event_datetime") }}'
+      - name: event_datetime
+        description: '[Required] {{ doc("event_datetime") }}'
+        tests:
+          - not_null:
+              severity: warn
+      - name: event_id
+        description: '[Required] {{ doc("event_id") }}'
+        tests:
+          - unique:
+              severity: warn
+          - not_null:
+              severity: warn
+      - name: event_name
+        description: '{{ doc("event_name") }}'
+      - name: event_source
+        description: '[Required] {{ doc("event_source") }}'
+        tests:
+          - not_null:
+              severity: warn
+      - name: event_type
+        description: '[Required] {{ doc("event_type") }}'
+        tests:
+          - not_null:
+              severity: warn
+      - name: group_id
+        description: '{{ doc("group_id") }}'
+      - name: host
+        description: '[Required] {{ doc("host") }}'
+        tests:
+          - not_null:
+              severity: warn
+      - name: modal_type
+        description: '[Required conditionally] {{ doc("modal_type") }}'
+        tests:
+          - not_null_where:
+              condition: "event_name similar to '%(opened_modal|closed_modal)%'"
+              severity: warn
+      - name: northstar_id
+        description: '{{ doc("northstar_id") }}'
+      - name: page_id
+        description: '{{ doc("page_id") }}'
+      - name: path
+        description: '[Required] {{ doc("path") }}'
+        tests:
+          - not_null:
+              severity: warn
+      - name: query_parameters
+        description: '{{ doc("query_parameters") }}'
+      - name: referrer_host
+        description: '{{ doc("referrer_host") }}'
+      - name: referrer_path
+        description: '{{ doc("referrer_path") }}'
+      - name: referrer_source
+        description: '{{ doc("referrer_source") }}'
+      - name: se_action
+        description: '[Required conditionally] {{ doc("se_action") }}'
+        tests:
+          - not_null_where:
+              condition: "event_type = 'se'"
+              severity: warn
+      - name: se_category
+        description: '[Required conditionally] {{ doc("se_category") }}'
+        tests:
+          - not_null_where:
+              condition: "event_type = 'se'"
+              severity: warn
+      - name: se_label
+        description: '{{ doc("se_label") }}'
+      - name: search_query
+        description: '{{ doc("search_query") }}'
+      - name: session_counter
+        description: '[Required] {{ doc("session_counter") }}'
+        tests:
+          - not_null:
+              severity: warn
+      - name: session_id
+        description: '[Required] {{ doc("session_id") }}'
+        tests:
+          - not_null:
+              severity: warn
+      - name: utm_campaign
+        description: '{{ doc("utm_campaign") }}'
+      - name: utm_medium
+        description: '{{ doc("utm_medium") }}'
+      - name: utm_source
+        description: '{{ doc("utm_source") }}'
 
   - name: snowplow_phoenix_events
     description: Table transforming snowplow_raw_event into rich derived data table for all clickstream info
@@ -251,38 +251,20 @@ models:
           description: '{{ doc("context_value") }}'
         - name: device_id
           description: '[Required] {{ doc("device_id") }}'
-          tests:
-            - not_null:
-                severity: warn
         - name: event_datetime
           description: '[Required] {{ doc("event_datetime") }}'
-          tests:
-            - not_null:
-                severity: warn
         - name: event_id
           description: '[Required] {{ doc("event_id") }}'
-          tests:
-            - unique:
-                severity: warn
-            - not_null:
-                severity: warn
         - name: event_name
           description: '{{ doc("event_name") }}'
         - name: event_source
           description: '[Required] {{ doc("event_source") }}'
-          tests:
-            - not_null:
-                severity: warn
         - name: group_id
           description: '{{ doc("group_id") }}'
         - name: host
           description: "URL domain"
         - name: modal_type
           description: '[Required conditionally] {{ doc("modal_type") }}'
-          tests:
-            - not_null_where:
-                condition: "event_name similar to '%(opened_modal|closed_modal)%'"
-                severity: warn
         - name: northstar_id
           description: '{{ doc("northstar_id") }}'
         - name: page_id
@@ -295,9 +277,6 @@ models:
           description: '{{ doc("utm_source") }}'
         - name: path
           description: '[Required] {{ doc("path") }}'
-          tests:
-            - not_null:
-                severity: warn
         - name: query_parameters
           description: '{{ doc("query_parameters") }}'
         - name: referrer_host

--- a/quasar/dbt/models/phoenix_events/snowplow_phoenix_events.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_phoenix_events.sql
@@ -1,33 +1,38 @@
+
+-- We are replicating all events from snowplow_raw_events just to add "campaign_name"
+-- FIXME: Condense with snowplow_raw_events
 SELECT DISTINCT ON (e.EVENT_ID)
-    e.event_id,
-    e.event_datetime,
-    CASE WHEN e.event_name IS NULL
-    AND e.event_type = 'pv'
-    THEN 'view' ELSE e.event_name END AS event_name,
-    e.event_source,
-    e."path",
-    e."host",
-    e.query_parameters,
+    e.block_id,
+    e.browser_size,
+    e.campaign_id,
+    i.campaign_name,
     e.clicked_link_url,
-    e.utm_source AS page_utm_source,
-    e.utm_medium AS page_utm_medium,
+    e.context_source,
+    e.context_value,
+    e.device_id,
+    e.event_datetime,
+    e.event_id,
+    CASE
+        WHEN e.event_name IS NULL
+        AND e.event_type = 'pv' THEN 'view'
+        ELSE e.event_name
+    END AS event_name,
+    e.event_source,
+    e.group_id,
+    e."host",
+    e.modal_type,
+    e.northstar_id,
+    e.page_id,
     e.utm_campaign AS page_utm_campaign,
+    e.utm_medium AS page_utm_medium,
+    e.utm_source AS page_utm_source,
+    e."path",
+    e.query_parameters,
     e.referrer_host,
     e.referrer_path,
     e.referrer_source,
-    e.campaign_id,
-    i.campaign_name,
-    e.page_id,
-    e.block_id,
-    e.group_id,
-    e.modal_type,
     e.search_query,
-    e.context_source,
-    e.context_value,
-    e.session_id,
-    e.browser_size,
-    e.northstar_id,
-    e.device_id
+    e.session_id
 FROM {{ ref('snowplow_raw_events') }} e
 LEFT JOIN {{ ref('campaign_info') }} i ON i.campaign_id = e.campaign_id::bigint
 

--- a/quasar/dbt/models/phoenix_events/snowplow_raw_events.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_raw_events.sql
@@ -1,3 +1,4 @@
+-- Combines attributes from the ft_snowplow.event and ft_snowplow.snowplow_event schemas
 SELECT
 	b.event_id,
 	b.event_source,


### PR DESCRIPTION
#### What's this PR do?
I took a look at the `snowplow_phoenix_events` model to implement schema tests. I found that we should not test this model. The only difference between this model and its parent `snowplow_raw_events` is the existence of the `campaign_name` column. We join `campaign_info` to pull this value. We could do just that in the parent node and save us the space.

```
relid   |schema_name|table_name             |table_size|indexes_size|total_size|
--------|-----------|-----------------------|----------|------------|----------|
23059596|public     |snowplow_phoenix_events|21 GB     |8997 MB     |29 GB     |
```
NOTE: Eliminating this model will require that we update old references and point them to `snowplow_raw_events`.

The changes in this PR, aside from comments, were just indentation and sorting related.

#### What are the relevant tickets? 
- https://www.pivotaltracker.com/story/show/173910879
