### PR TITLE
Schema tests for Snowplow sessions model

### DIFF
--- a/quasar/dbt/macros/test_is_between.sql
+++ b/quasar/dbt/macros/test_is_between.sql
@@ -1,0 +1,22 @@
+-- Source https://discourse.getdbt.com/t/examples-of-custom-schema-tests/181/5
+{% macro test_is_between(model, column_name, bottom_number, top_number) %}
+    WITH validation AS (
+        SELECT
+            {{ column_name }} AS field_to_test
+        FROM
+            {{ model }}
+    ),
+    validation_errors AS (
+        SELECT
+            field_to_test
+        FROM
+            validation
+        WHERE
+            field_to_test > {{ top_number }}
+            OR field_to_test < {{ bottom_number }}
+    )
+    SELECT
+        count(*)
+    FROM
+        validation_errors
+{% endmacro %}

--- a/quasar/dbt/macros/test_relationships_distinct.sql
+++ b/quasar/dbt/macros/test_relationships_distinct.sql
@@ -1,12 +1,19 @@
+-- This Macro tests that the row with a given column value
+-- is not orphan by searching for the value in a model and field that should
+-- contain the entity.
+
+-- Example of the arguments passed to this macro
+-- model: public.snowplow_base_event (provided by DBT - Model being tested in schema.yml)
+-- column_name: northstar_id (provided by DBT -- column being tested in schema.yml)
+-- to: public.users (provided by user -- "to" model to compare against)
+-- field: northstar_id (provided by user -- "field" in "to" model to compare against)
 {% macro test_relationships_distinct(model, field, to, column_name) %}
-
-SELECT
-    count(DISTINCT {{"a.%s" | format(column_name) }}) AS orphan_ids
-FROM
-    {{"%s a" | format(model) }}
-    LEFT JOIN {{"%s b" | format(to) }} ON {{"a.%s" | format(column_name) }} = {{"b.%s" | format(field) }}
-WHERE
-    {{"a.%s" | format(column_name) }} IS NOT NULL
-    AND {{"b.%s" | format(field) }} IS NULL
-
+    SELECT
+        count(DISTINCT {{"a.%s" | format(column_name) }}) AS orphan_ids
+    FROM
+        {{"%s a" | format(model) }}
+        LEFT JOIN {{"%s b" | format(to) }} ON {{"a.%s" | format(column_name) }} = {{"b.%s" | format(field) }}
+    WHERE
+        {{"a.%s" | format(column_name) }} IS NOT NULL
+        AND {{"b.%s" | format(field) }} IS NULL
 {% endmacro %}

--- a/quasar/dbt/models/phoenix_events/phoenix_sessions_combined.sql
+++ b/quasar/dbt/models/phoenix_events/phoenix_sessions_combined.sql
@@ -20,7 +20,7 @@ WHERE p.landing_datetime >= (select max(psc.landing_datetime) from {{this}} psc)
 UNION ALL
 SELECT
     s.session_id,
-    s.event_id,
+    s.first_event_id,
     s.device_id,
     s.landing_datetime,
     s.ending_datetime,
@@ -37,4 +37,3 @@ FROM {{ ref('snowplow_sessions') }} s
 -- this filter will only be applied on an incremental run
 WHERE s.landing_datetime >= (select max(psc.landing_datetime) from {{this}} psc)
 {% endif %}
-

--- a/quasar/dbt/models/phoenix_events/schema.yml
+++ b/quasar/dbt/models/phoenix_events/schema.yml
@@ -294,25 +294,57 @@ models:
     description: Table containing user session data derived from snowplow_phoenix_events
     columns:
         - name: days_since_last_session
-          description: '{{ doc("days_since_last_session") }}'
+          description: '[Required] {{ doc("days_since_last_session") }}'
+          tests:
+            - not_null:
+                severity: warn
         - name: device_id
-          description: '{{ doc("device_id") }}'
+          description: '[Required] {{ doc("device_id") }}'
+          tests:
+            - unique:
+                severity: warn
+            - not_null:
+                severity: warn
         - name: ending_datetime
-          description: '{{ doc("ending_datetime") }}'
+          description: '[Required] {{ doc("ending_datetime") }}'
+          tests:
+            - not_null:
+                severity: warn
         - name: event_id
-          description: '{{ doc("event_id") }}'
+          description: '[Required] First event id of the session. {{ doc("event_id") }}'
+          tests:
+            - not_null:
+                severity: warn
         - name: exit_page
-          description: '{{ doc("exit_page") }}'
+          description: '[Required] {{ doc("exit_page") }}'
+          tests:
+            - not_null:
+                severity: warn
         - name: landing_datetime
-          description: '{{ doc("landing_datetime") }}'
+          description: '[Required] {{ doc("landing_datetime") }}'
+          tests:
+            - not_null:
+                severity: warn
         - name: landing_page
-          description: '{{ doc("landing_page") }}'
-        - name: num_pages_views
-          description: '{{ doc("num_pages_views") }}'
+          description: '[Required] {{ doc("landing_page") }}'
+          tests:
+            - not_null:
+                severity: warn
+        - name: num_pages_viewed
+          description: '[Required] {{ doc("num_pages_viewed") }}'
+          tests:
+            - not_null:
+                severity: warn
         - name: session_duration_seconds
-          description: '{{ doc("session_duration_seconds") }}'
+          description: '[Required] {{ doc("session_duration_seconds") }}'
+          tests: # also add custom range test, sessions shouldn't last more than 1 hour
+            - not_null:
+                severity: warn
         - name: session_id
-          description: '{{ doc("session_id") }}'
+          description: '[Required] {{ doc("session_id") }}'
+          tests:
+            - not_null:
+                severity: warn
         - name: session_referrer_host
           description: '{{ doc("referrer_host") }} For this session.'
         - name: session_utm_campaign
@@ -415,8 +447,8 @@ models:
         - name: session_duration_seconds
           description: '{{ doc("session_duration_seconds") }}'
 
-        - name: num_pages_views
-          description: '{{ doc("num_pages_views") }}'
+        - name: num_pages_viewed
+          description: '{{ doc("num_pages_viewed") }}'
 
         - name: landing_page
           description: '{{ doc("landing_page") }}'

--- a/quasar/dbt/models/phoenix_events/schema.yml
+++ b/quasar/dbt/models/phoenix_events/schema.yml
@@ -337,8 +337,10 @@ models:
                 severity: warn
         - name: session_duration_seconds
           description: '[Required] {{ doc("session_duration_seconds") }}'
-          tests: # also add custom range test, sessions shouldn't last more than 1 hour
-            - not_null:
+          tests:
+            - is_between:
+                bottom_number: 0
+                top_number: 3600 # seconds
                 severity: warn
         - name: session_id
           description: '[Required] {{ doc("session_id") }}'

--- a/quasar/dbt/models/phoenix_events/schema.yml
+++ b/quasar/dbt/models/phoenix_events/schema.yml
@@ -293,36 +293,32 @@ models:
   - name: snowplow_sessions
     description: Table containing user session data derived from snowplow_phoenix_events
     columns:
-        - name: session_id
-          description: '{{ doc("session_id") }}'
-
-        - name: event_id
-          description: '{{ doc("event_id") }}'
-
-        - name: device_id
-          description: '{{ doc("device_id") }}'
-
-        - name: landing_datetime
-          description: '{{ doc("landing_datetime") }}'
-
-        - name: ending_datetime
-          description: '{{ doc("ending_datetime") }}'
-
-        - name: session_duration_seconds
-          description: '{{ doc("session_duration_seconds") }}'
-
-        - name: num_pages_views
-          description: '{{ doc("num_pages_views") }}'
-
-        - name: landing_page
-          description: '{{ doc("landing_page") }}'
-
-        - name: exit_page
-          description: '{{ doc("exit_page") }}'
-
         - name: days_since_last_session
           description: '{{ doc("days_since_last_session") }}'
-
+        - name: device_id
+          description: '{{ doc("device_id") }}'
+        - name: ending_datetime
+          description: '{{ doc("ending_datetime") }}'
+        - name: event_id
+          description: '{{ doc("event_id") }}'
+        - name: exit_page
+          description: '{{ doc("exit_page") }}'
+        - name: landing_datetime
+          description: '{{ doc("landing_datetime") }}'
+        - name: landing_page
+          description: '{{ doc("landing_page") }}'
+        - name: num_pages_views
+          description: '{{ doc("num_pages_views") }}'
+        - name: session_duration_seconds
+          description: '{{ doc("session_duration_seconds") }}'
+        - name: session_id
+          description: '{{ doc("session_id") }}'
+        - name: session_referrer_host
+          description: '{{ doc("referrer_host") }} For this session.'
+        - name: session_utm_campaign
+          description: '{{ doc("utm_campaign") }} For this session.'
+        - name: session_utm_source
+          description: '{{ doc("utm_source") }} For this session.'
   - name: phoenix_events_combined
     description: Table combining Snowplow based web event data with legacy Puck data based on 7/12/2019 cutover date
     columns:

--- a/quasar/dbt/models/phoenix_events/schema.yml
+++ b/quasar/dbt/models/phoenix_events/schema.yml
@@ -310,7 +310,7 @@ models:
           tests:
             - not_null:
                 severity: warn
-        - name: event_id
+        - name: first_event_id
           description: '[Required] First event id of the session. {{ doc("event_id") }}'
           tests:
             - not_null:

--- a/quasar/dbt/models/phoenix_events/snowplow_sessions.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_sessions.sql
@@ -25,8 +25,8 @@ SELECT
     session_id,
     first_value("path") OVER (PARTITION BY session_id ORDER BY event_datetime
 	ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS landing_page,
-    first_value(event_id) OVER (PARTITION BY session_id ORDER BY event_datetime 
-	ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS event_id,
+    first_value(event_id) OVER (PARTITION BY session_id ORDER BY event_datetime
+	ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS first_event_id,
     last_value("path") OVER (PARTITION BY session_id ORDER BY event_datetime
 	ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS exit_page
 FROM {{ ref('snowplow_phoenix_events') }}
@@ -67,7 +67,7 @@ WHERE landing_datetime >= (select max(ss.landing_datetime) from {{this}} ss)
 )
 SELECT DISTINCT
 s.session_id,
-p.event_id,
+p.first_event_id,
 s.device_id,
 s.landing_datetime,
 s.ending_datetime,

--- a/quasar/dbt/models/phoenix_events/snowplow_sessions.sql
+++ b/quasar/dbt/models/phoenix_events/snowplow_sessions.sql
@@ -78,7 +78,8 @@ s.session_duration_seconds,
 s.num_pages_viewed,
 p.landing_page,
 p.exit_page,
-date_part('day', s.landing_datetime - t.prev_session_endtime) AS days_since_last_session
+-- default to 0 days if there was no previous session
+COALESCE(date_part('day', s.landing_datetime - t.prev_session_endtime),0) AS days_since_last_session
 FROM sessions s
 LEFT JOIN entry_exit_pages p
 ON p.session_id = s.session_id

--- a/quasar/dbt/models/schema.md
+++ b/quasar/dbt/models/schema.md
@@ -316,7 +316,7 @@ ID of the device used
 {% enddocs %}
 
 {% docs referrer_host %}
-URL host of the referring site (eg. google.com). Only present if session is referred from some external site link (ex. Facebook, Google, Bing).
+URL host of the referring site (eg. google.com). Only present if session is referred from some external site link (ex. Facebook, Google, Bing). This would be NULL for anyone directly typing dosomething.org into a browser
 {% enddocs %}
 
 {% docs referrer_path %}
@@ -352,19 +352,19 @@ Certain pages have modals and therefore certain event actions will have it (e.g.
 {% enddocs %}
 
 {% docs landing_datetime %}
-When the session started in UTC (eg. 2018-01-01 12:00:00)
+Timestamp of when the session started, in UTC (eg. 2018-01-01 12:00:00)
 {% enddocs %}
 
 {% docs ending_datetime %}
-When the session ended in UTC (eg. 2018-01-01 12:00:00)
+Timestamp of when the session ended, in UTC (eg. 2018-01-01 12:00:00)
 {% enddocs %}
 
 {% docs session_duration_seconds %}
-Session duration in seconds
+Session duration in seconds.
 {% enddocs %}
 
-{% docs num_pages_views %}
-Number of pages viewed in session
+{% docs num_pages_viewed %}
+Number of view events in this session.
 {% enddocs %}
 
 {% docs landing_page %}
@@ -372,7 +372,7 @@ First page the user viewed in the session (eg. /us/facts/11-facts-about-bp-oil-s
 {% enddocs %}
 
 {% docs exit_page %}
-"Which page the user ended or exited their session from (eg. /us/campaigns/green-your-getaway)"
+Which page the user ended or exited their session from (eg. /us/campaigns/green-your-getaway)
 {% enddocs %}
 
 {% docs days_since_last_session %}


### PR DESCRIPTION
#### What's this PR do?
- Adds schema tests for `snowplow_sessions` model
- Updates documentation

NOTES:
- We need update any Looker model that used the `snowplow_session`'s `event_id` column. It has been renamed to `first_event_id`.
- This change requires a full Snowplow events refresh. It took over a day last time we did this. 

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/173911069

