### PR TITLE
Bugfix phoenix_sessions_combined event_id to first_event_id

### DIFF
--- a/quasar/dbt/models/phoenix_events/phoenix_sessions_combined.sql
+++ b/quasar/dbt/models/phoenix_events/phoenix_sessions_combined.sql
@@ -1,6 +1,6 @@
 SELECT 
     p.session_id,
-    p.event_id,
+    p.event_id as first_event_id,
     p.device_id,
     p.landing_datetime,
     p.end_datetime as ending_datetime,


### PR DESCRIPTION
#### What's this PR do?
- Fixes bug where I forgot to update the historical column `event_id` to `first_event_id`
#### What are the relevant tickets?
- https://github.com/DoSomething/quasar/pull/1097

