### PR TITLE
Removing references to historical_analytics events and session tables

### DIFF
--- a/quasar/dbt/models/phoenix_events/phoenix_events_combined.sql
+++ b/quasar/dbt/models/phoenix_events/phoenix_events_combined.sql
@@ -1,38 +1,3 @@
-SELECT DISTINCT ON(p.event_datetime, p.event_name, p.event_id)
-    p.event_id,
-    p.event_datetime,
-    p.event_name,
-    p.event_source,
-    p."path",
-    p."host",
-    NULL AS query_parameters,
-    NULL AS clicked_link_url,
-    p.page_utm_source,
-    p.page_utm_medium,
-    p.page_utm_campaign,
-    p.referrer_host,
-    p.referrer_path,
-    p.referrer_source,
-    p.campaign_id,
-    p.campaign_name,
-    NULL AS page_id,
-    NULL AS block_id,
-    NULL AS group_id,
-    p.modal_type,
-    NULL AS search_query,
-    NULL AS context_source,
-    NULL AS context_value,
-    p.session_id,
-    p.browser_size,
-    p.northstar_id,
-    p.device_id
-FROM
-    {{ source('web_events_historical', 'phoenix_events') }} p
-{% if is_incremental() %}
--- this filter will only be applied on an incremental run
-    WHERE p.event_datetime >= (SELECT max(pec.event_datetime) FROM {{this}} pec)
-{% endif %}
-UNION ALL
 SELECT DISTINCT ON(s.event_datetime, s.event_name, s.event_id)
     s.event_id,
     s.event_datetime,

--- a/quasar/dbt/models/phoenix_events/phoenix_sessions_combined.sql
+++ b/quasar/dbt/models/phoenix_events/phoenix_sessions_combined.sql
@@ -1,23 +1,3 @@
-SELECT 
-    p.session_id,
-    p.event_id as first_event_id,
-    p.device_id,
-    p.landing_datetime,
-    p.end_datetime as ending_datetime,
-    p.referrer_host as session_referrer_host,
-    p.utm_source as session_utm_source,
-    p.utm_campaign as session_utm_campaign,
-    EXTRACT(EPOCH FROM (end_datetime - landing_datetime)) AS session_duration_seconds,
-    NULL as num_pages_viewed,
-    p.landing_page,
-    NULL as exit_page,
-    NULL as days_since_last_session
-FROM {{ source('web_events_historical', 'phoenix_sessions') }} p
-{% if is_incremental() %}
--- this filter will only be applied on an incremental run
-WHERE p.landing_datetime >= (select max(psc.landing_datetime) from {{this}} psc)
-{% endif %}
-UNION ALL
 SELECT
     s.session_id,
     s.first_event_id,


### PR DESCRIPTION
#### What's this PR do?
This PR removes references to the `historical_analytics.phoenix_events` and `historical_analytics.phoenix_sessions` tables. 
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/175501887
#### Screenshots (if appropriate)
#### Questions:
