### PR TITLE
Fix small index bug in cio_email_events

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -424,7 +424,6 @@ models:
             - "CREATE INDEX {{ get_index_name(this, 'email_id') }} (email_id)"
             - "CREATE INDEX {{ get_index_name(this, 'template_id') }} (template_id)"
             - "CREATE INDEX {{ get_index_name(this, 'customer_id') }} (customer_id)"
-            - "CREATE INDEX {{ get_index_name(this, 'event_id') }} (event_id)"
             - "CREATE INDEX {{ get_index_name(this, 'timestamp_nulls_first') }} (timestamp nulls first)"
             - "CREATE INDEX {{ get_index_name(this, 'timestamp_nulls_first_event_type') }} (timestamp nulls first, event_type)"
             - "{{ grant_select_to(this, ['dsanalyst', 'looker']) }}"


### PR DESCRIPTION
#### What's this PR do?
Fixes small bug that duplicated the `event_id` index in the `cio_email_events` model

#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/175005028
