### PR TITLE
Fixes GDPR script bug due to the CIO tables renaming

### DIFF
--- a/data/sql/misc/gdpr_cio_removal.sql
+++ b/data/sql/misc/gdpr_cio_removal.sql
@@ -3,24 +3,12 @@ UPDATE :customer_event
 		event_id = NULL
 	WHERE customer_id IN (SELECT _id FROM :users.northstar_users_snapshot WHERE deleted_at IS NOT NULL);
 
-UPDATE :email_bounced
-	SET email_address = NULL,
-		event_id = NULL,
-		subject = NULL
-	WHERE customer_id IN (SELECT _id FROM :users.northstar_users_snapshot WHERE deleted_at IS NOT NULL);
-
-UPDATE :email_event
+UPDATE :email_events
 	SET email_address = NULL,
 		event_id = NULL,
 		subject = NULL,
 		href = NULL,
 		link_id = NULL
-	WHERE customer_id IN (SELECT _id FROM :users.northstar_users_snapshot WHERE deleted_at IS NOT NULL);
-
-UPDATE :email_sent
-	SET email_address = NULL,
-		event_id = NULL,
-		subject = NULL
 	WHERE customer_id IN (SELECT _id FROM :users.northstar_users_snapshot WHERE deleted_at IS NOT NULL);
 
 DELETE FROM :event_log


### PR DESCRIPTION
#### What's this PR do?
- Fixes GDPR script. It has been failing for the past few weeks due to an outdated query that references old CIO tables.

[link](https://jenkins.d12g.co/job/GDPR%20Compliance/40/console) to logged error in Jenkins.