### PR TITLE
Adds pessimistic timestamp type casting for 'Started registration' in `rock_the_vote` model.

### DIFF
--- a/quasar/dbt/models/campaign_activity/rock_the_vote.sql
+++ b/quasar/dbt/models/campaign_activity/rock_the_vote.sql
@@ -1,7 +1,14 @@
 SELECT id AS post_id,
    details::jsonb->>'Tracking Source' AS tracking_source,
-   (details::jsonb->>'Started registration')::timestamp AS started_registration,
-   (details::jsonb->>'Started registration')::timestamptz AS started_registration_utc,
+   -- is_date_string is a function that checks if the text string value casts
+   -- to a timestamptz successfully. It sets the value to NULL if it fails.
+   -- Bug Card: https://www.pivotaltracker.com/story/show/176447082
+   case when is_date_string(details::jsonb->>'Started registration') is true
+    then (details::jsonb->>'Started registration')::timestamp
+    else null end AS started_registration,
+   case when is_date_string(details::jsonb->>'Started registration') is true
+    then (details::jsonb->>'Started registration')::timestamptz
+    else null end AS started_registration_utc,
    details::jsonb->>'Finish with State' AS finish_with_state,
    details::jsonb->>'Status' AS status,
    COALESCE(details::jsonb->>'Email address',details::jsonb->>'email') AS email,


### PR DESCRIPTION
#### What's this PR do?
- Adds the use of a user defined function to prevent casting invalid text into timestamp.

Function defined in QA and Production:
```
create or replace function is_date_string(date_string text) returns boolean as $$
begin
	if date_string is null then
		return false;
	end if;
	perform date_string::timestamptz;
    return true;
exception when others then
	return false;
end;
$$ LANGUAGE plpgsql
immutable;
```

Tested locally against QA:
```
pipenv run dbt run -m campaign_activity.rock_the_vote --profile qa
Running with dbt=0.18.1
Found 49 models, 88 tests, 3 snapshots, 0 analyses, 143 macros, 0 operations, 0 seed files, 24 sources

12:05:38 | Concurrency: 4 threads (target='default')
12:05:38 | 
12:05:38 | 1 of 1 START table model public.rock_the_vote........................ [RUN]
12:06:07 | 1 of 1 OK created table model public.rock_the_vote................... [SELECT 845664 in 29.00s]
12:06:08 | 
12:06:08 | Finished running 1 table model in 33.21s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

Test cases passed:
```
-- tests
select is_date_string('20200101'); -- t
select is_date_string('2021-01-01'); -- t
select is_date_string(''); -- f
select is_date_string(null); -- f
select is_date_string('123-456-789'); -- f
```
#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/176447082
