### PR TITLE
Feature/expose hours spent

### DIFF
--- a/quasar/dbt/models/campaign_activity/posts.sql
+++ b/quasar/dbt/models/campaign_activity/posts.sql
@@ -24,7 +24,7 @@ SELECT
 	a.quiz AS is_quiz,
 	a.reportback AS is_reportback,
 	a.scholarship_entry AS is_scholarship_entry,
-	a.time_commitment AS is_time_commitment,
+	a.time_commitment AS time_commitment,
 	a.volunteer_credit AS is_volunteer_credit,
 	pd.location,
 	pd.northstar_id AS northstar_id,
@@ -65,12 +65,13 @@ SELECT
 	pd.status AS "status",
 	pd.text,
 	pd."type" AS "type",
+	pd.hours_spent,
 	pd.url AS url,
 	a.verb,
 	CASE
 		WHEN rtv.tracking_source='ads'
 		THEN 'ads'
-		ELSE split_part(substring(rtv.tracking_source from 'source\:(.+)'), ',', 1) 
+		ELSE split_part(substring(rtv.tracking_source from 'source\:(.+)'), ',', 1)
 	END AS vr_source,
 	split_part(substring(rtv.tracking_source from 'source_details\:(.+)'), ',', 1) AS vr_source_details
 FROM {{ source('rogue', 'posts') }} pd

--- a/quasar/dbt/models/campaign_activity/reportbacks.sql
+++ b/quasar/dbt/models/campaign_activity/reportbacks.sql
@@ -39,6 +39,7 @@ SELECT
 	pd.source AS post_source,
 	pd.source_bucket AS post_source_bucket,
 	pd.status AS post_status,
+	pd.hours_spent as hours_spent,
 	pd.created_at AS post_created_at,
 	pd.postal_code,
 	CASE

--- a/quasar/dbt/models/campaign_activity/schema.yml
+++ b/quasar/dbt/models/campaign_activity/schema.yml
@@ -35,6 +35,8 @@ models:
         description: Club id
       - name: created_at
         description: '{{ doc("created_at") }}'
+      - name: hours_spent
+        description: '{{ doc("hours_spent") }}'
       - name: id
         description: '{{ doc("id") }}'
       - name: is_accepted
@@ -119,6 +121,9 @@ models:
       - name: scholarship_entry
         description: '{{ doc("scholarship_entry") }}'
 
+      - name: hours_spent
+        description: '{{ doc("hours_spent") }}'
+        
       - name: location
         description: '{{ doc("location") }}'
 

--- a/quasar/dbt/models/schema.md
+++ b/quasar/dbt/models/schema.md
@@ -96,7 +96,7 @@ When the item was updated in UTC (eg. 2018-01-01 12:00:00)
 {% enddocs %}
 
 {% docs text %}
-Text of the post (e.g. "Zoo animals and a super hero trying to help too!") 
+Text of the post (e.g. "Zoo animals and a super hero trying to help too!")
 {% enddocs %}
 
 {% docs signup_id %}
@@ -404,15 +404,15 @@ Marks rows that were deleted in the source table
 {% enddocs %}
 
 {% docs reportback %}
-Whether the post is a reportback 
+Whether the post is a reportback
 {% enddocs %}
 
 {% docs active %}
-Whether the user is active 
+Whether the user is active
 {% enddocs %}
 
 {% docs anonymous %}
-Whether the user is anonymous when making the post 
+Whether the user is anonymous when making the post
 {% enddocs %}
 
 {% docs callpower_campaign_id %}
@@ -420,7 +420,7 @@ Unique ID corresponding to the Callpower campaign. Callpower allows users to rec
 {% enddocs %}
 
 {% docs quiz %}
-Whether the post is a quiz 
+Whether the post is a quiz
 {% enddocs %}
 
 {% docs action_type %}
@@ -508,7 +508,7 @@ Timestamp of when user unsubscribed from email or sms
 {% enddocs %}
 
 {% docs voter_reg_acquisition %}
-Whether the user was an acquisition through voter registration efforts. 
+Whether the user was an acquisition through voter registration efforts.
 {% enddocs %}
 
 {% docs last_logged_in %}
@@ -544,7 +544,7 @@ User's last name
 {% enddocs %}
 
 {% docs voter_registration_status %}
-User's registration status. (e.g. registration_complete, confirmed, uncertain) 
+User's registration status. (e.g. registration_complete, confirmed, uncertain)
 {% enddocs %}
 
 {% docs finish_with_state %}
@@ -596,15 +596,15 @@ Details of the origin of the user. (e.g. tell_a_friend, other, opt_in_path/19798
 {% enddocs %}
 
 {% docs badges %}
-Whether the user has any badges. 
+Whether the user has any badges.
 {% enddocs %}
 
 {% docs refer_friends %}
-Whether the user is a part of the refer a friend campaign. 
+Whether the user is a part of the refer a friend campaign.
 {% enddocs %}
 
 {% docs subscribed_member %}
-Whether the user is subscribed. 
+Whether the user is subscribed.
 {% enddocs %}
 
 {% docs last_updated_at %}
@@ -877,4 +877,8 @@ The goal of the group
 
 {% docs group_name %}
 The name of the group
+{% enddocs %}
+
+{% docs hours_spent %}
+The number of hours spent for a specific action. Entered by member
 {% enddocs %}


### PR DESCRIPTION
#### What's this PR do?

- Adds the hours_spent field for volunteer credits to the posts and reportbacks model
- Also makes a minor update to the name of the field is_time_commitment --> time_commitment (since it's not a boolean flag)

#### Any background context you want to provide?

Tested locally in QA:

```
Params-MBP:dbt pghangas$ pipenv run dbt run -m campaign_activity.posts --profile qa
Running with dbt=0.18.1
Found 49 models, 88 tests, 3 snapshots, 0 analyses, 143 macros, 0 operations, 0 seed files, 24 sources

15:48:17 | Concurrency: 4 threads (target='default')
15:48:17 | 
15:48:17 | 1 of 1 START table model public.posts................................ [RUN]
15:48:47 | 1 of 1 OK created table model public.posts........................... [SELECT 2265977 in 30.52s]
15:48:48 | 
15:48:48 | Finished running 1 table model in 31.62s.

Completed successfully
```

#### What are the relevant tickets?

- https://www.pivotaltracker.com/story/show/176384079
