### PR TITLE
bugfix for Northstar Snapshot new jsonb column: email_subscription_topics

### DIFF
--- a/quasar/dbt/models/news_subscription/email_subscription_topics_raw.sql
+++ b/quasar/dbt/models/news_subscription/email_subscription_topics_raw.sql
@@ -1,6 +1,6 @@
 SELECT DISTINCT
 	_id as northstar_id,
 	(audit #>> '{email_subscription_topics,updated_at,date}')::timestamp AS newsletter_updated_at,
-	json_array_elements(u.email_subscription_topics)::TEXT AS newsletter_topic
+	json_array_elements(u.email_subscription_topics::json)::TEXT AS newsletter_topic
 FROM {{ source('northstar', 'northstar_users_snapshot') }} u
 WHERE audit #>> '{email_subscription_topics,updated_at,date}' IS NOT NULL


### PR DESCRIPTION
#### What's this PR do?
Model: `news_subscription.email_subscription_topics_raw`.

It updates the query `json_array_elements(u.email_subscription_topics)::TEXT AS newsletter_topic` and casts `email_subscription_topics` to `::json`.

Fixes error:
```
Database Error in model email_subscription_topics_raw (models/news_subscription/email_subscription_topics_raw.sql)
  function json_array_elements(jsonb) does not exist
  LINE 9:  json_array_elements(u.email_subscription_topics)::TEXT AS n...
           ^
  HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
  compiled SQL at ../../docs/run/ds_dbt/models/news_subscription/email_subscription_topics_raw.sql
```
#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/176196749
