### PR TITLE
Removes Zendesk DBT model

### DIFF
--- a/quasar/dbt/dbt_project.yml
+++ b/quasar/dbt/dbt_project.yml
@@ -429,7 +429,3 @@ models:
           +post-hook:
             - "{{ grant_select_to(this, ['dsanalyst', 'looker']) }}"
           +tags: "nps"
-vars:
-  zendesk_source:
-    zendesk_database: quasar
-    zendesk_schema: ft_zendesk

--- a/quasar/dbt/packages.yml
+++ b/quasar/dbt/packages.yml
@@ -1,6 +1,3 @@
 packages:
   - package: fishtown-analytics/dbt_utils
     version: 0.6.2
-packages:
-  - package: fivetran/zendesk
-    version: 0.1.0


### PR DESCRIPTION
#### What's this PR do?
It removes v1 of the Zendesk model. We need to do a quick review of the configurations before submitting V2.
